### PR TITLE
[connector-lifecycle phase 1] IConnector start/stop pure-virtuals

### DIFF
--- a/connectors/market/include/gma/market/MarketConnector.hpp
+++ b/connectors/market/include/gma/market/MarketConnector.hpp
@@ -43,6 +43,8 @@ public:
   // shutdown steps on reg.shutdown. Returns with the servers running inside
   // reg.io (which the caller drives via io.run()).
   void registerWith(engine::EngineRegistries& reg) override;
+  void start() override;
+  void stop() noexcept override;
 
 private:
   std::shared_ptr<OrderBookManager>                  _obManager;

--- a/connectors/market/src/MarketConnector.cpp
+++ b/connectors/market/src/MarketConnector.cpp
@@ -28,6 +28,16 @@ namespace gma::market {
 MarketConnector::MarketConnector()  = default;
 MarketConnector::~MarketConnector() = default;
 
+void MarketConnector::start() {
+  // TODO: phase-4 — move feed run/client start/OB init from registerWith into
+  // start; mirror in stop.
+}
+
+void MarketConnector::stop() noexcept {
+  // TODO: phase-4 — reverse-order teardown of feed clients, feed server, and
+  // AtomicProviderRegistry.
+}
+
 void MarketConnector::installDefaults() {
   Dispatcher::setDefaultComputerFactory(
     [](const util::Config& cfg) {

--- a/connectors/synthetic/include/gma/synthetic/SyntheticConnector.hpp
+++ b/connectors/synthetic/include/gma/synthetic/SyntheticConnector.hpp
@@ -31,6 +31,8 @@ public:
 
   std::string_view name() const override { return "synthetic"; }
   void registerWith(engine::EngineRegistries& reg) override;
+  void start() override;
+  void stop() noexcept override;
 
 private:
   Options                               _opts;

--- a/connectors/synthetic/src/SyntheticConnector.cpp
+++ b/connectors/synthetic/src/SyntheticConnector.cpp
@@ -34,6 +34,15 @@ SyntheticConnector::SyntheticConnector() = default;
 SyntheticConnector::SyntheticConnector(Options opts) : _opts(std::move(opts)) {}
 SyntheticConnector::~SyntheticConnector() = default;
 
+void SyntheticConnector::start() {
+  // TODO: phase-4 — move timer arm (expires_after + async_wait) here.
+}
+
+void SyntheticConnector::stop() noexcept {
+  // TODO: phase-4 — cancel the timer here (currently done via the
+  // synthetic-timer-cancel ShutdownCoordinator step).
+}
+
 void SyntheticConnector::registerWith(engine::EngineRegistries& reg) {
   if (!reg.dispatcher || !reg.io) {
     throw std::runtime_error("SyntheticConnector: incomplete EngineRegistries");

--- a/include/gma/engine/IConnector.hpp
+++ b/include/gma/engine/IConnector.hpp
@@ -5,16 +5,28 @@
 namespace gma::engine {
 
 // Contract every connector implements. The composition root constructs one
-// instance per linked connector and calls registerWith() once at boot. The
-// connector publishes its event types, computers, node types, config readers,
-// and ingress sources through the various engine registries (most of which
-// are static singletons, so not passed via EngineRegistries).
+// instance per linked connector and drives it through a strict lifecycle:
+//
+//   1. registerWith(EngineRegistries&) — exactly once. Publish event types,
+//      computers, node types, config readers, ingress sources, and atomic
+//      providers via the engine registries; allocate (but do not run) any
+//      sockets, timers, or background threads.
+//   2. start() — exactly once, after registerWith. Bring sources online: run
+//      servers, connect clients, arm timers. May throw on failure.
+//   3. stop() noexcept — exactly once, after start (idempotent on extra
+//      calls). Tear down everything started in start(), in reverse order.
+//      Safe to call from a ShutdownCoordinator step.
+//
+// Static engine registries (NodeTypeRegistry, FunctionMap, …) are accessed
+// through their own singletons and not re-exposed here.
 class IConnector {
 public:
   virtual ~IConnector() = default;
 
   virtual std::string_view name() const = 0;
   virtual void registerWith(EngineRegistries&) = 0;
+  virtual void start() = 0;
+  virtual void stop() noexcept = 0;
 };
 
 } // namespace gma::engine

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,6 +4,9 @@
 #include <iostream>
 #include <memory>
 #include <string>
+#include <vector>
+
+#include "gma/engine/IConnector.hpp"
 
 // -------- Engine --------
 #include "gma/AtomicStore.hpp"
@@ -133,13 +136,25 @@ int main(int argc, char* argv[]) {
   shutdown.registerStep("ws-close-sessions", 40, [&ws]{ try { ws.closeAll(); } catch (...) {} });
   shutdown.registerStep("asio-stop",         60, [&ioc]{ try { ioc.stop(); } catch (...) {} });
 
-  // 8) Connector registration — a single line per connector.
+  // 8) Connector registration — construct → registerWith → start, with a
+  //    single ShutdownCoordinator step that calls stop() in reverse-registration
+  //    order. With one connector today the reverse-order is trivial; the
+  //    pattern is future-proof.
   gma::engine::EngineRegistries regs{
     &cfg, gma::gThreadPool.get(), store.get(), dispatcher.get(), &shutdown, &ioc
   };
+  std::vector<gma::engine::IConnector*> connectors;
   gma::market::MarketConnector marketConnector;
   marketConnector.registerWith(regs);
+  connectors.push_back(&marketConnector);
   // (future) gma::crypto::CoinbaseConnector{}.registerWith(regs);
+
+  for (auto* c : connectors) c->start();
+  shutdown.registerStep("connectors-stop", 30, [&connectors] {
+    for (auto it = connectors.rbegin(); it != connectors.rend(); ++it) {
+      (*it)->stop();
+    }
+  });
 
   logger().log(
     LogLevel::Info,

--- a/tests/integration/IntegrationTest.cpp
+++ b/tests/integration/IntegrationTest.cpp
@@ -11,6 +11,7 @@
 #include "gma/SymbolHistory.hpp"
 #include "gma/util/Config.hpp"
 #include <gtest/gtest.h>
+#include <algorithm>
 #include <memory>
 #include <fstream>
 #include <cstdio>


### PR DESCRIPTION
First of four stacked PRs implementing the **connector-lifecycle** project from Linear. This PR is additive — no behavior changes.

## Summary
- `IConnector` adds pure-virtual `start()` / `stop() noexcept` with the lifecycle order documented (`registerWith → start → stop`).
- `MarketConnector` and `SyntheticConnector` ship no-op stubs with phase-4 TODOs.
- `main.cpp` calls `start()` after `registerWith` and registers a single `connectors-stop` ShutdownCoordinator step at priority 30 that stops connectors in reverse-registration order.
- Drive-by: add missing `<algorithm>` include in `tests/integration/IntegrationTest.cpp` (was blocking ctest under GCC 16).

## Linear
Closes ENC-51, ENC-52, ENC-53, ENC-54. Partially satisfies AC1 (ENC-70) — full satisfaction lands in phase 4.

## Test plan
- [x] `ctest --output-on-failure` — 365/365 pass
- [x] `gma_server` builds and links
- [ ] No `registerStep` removed yet (phase 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)