### PR TITLE
[connector-lifecycle phase 2] EngineRegistries 14-field expansion

### DIFF
--- a/include/gma/atomic/AtomicProviderRegistry.hpp
+++ b/include/gma/atomic/AtomicProviderRegistry.hpp
@@ -12,6 +12,13 @@ class AtomicProviderRegistry {
 public:
   using ProviderFn = std::function<double(const std::string& symbol, const std::string& fullKey)>;
 
+  // Tag instance — registry methods are static, so this is purely a handle for
+  // EngineRegistries to expose alongside the per-instance singletons.
+  static AtomicProviderRegistry& singleton() {
+    static AtomicProviderRegistry s;
+    return s;
+  }
+
   // Register (or replace) a provider function for a namespace, e.g., "ema", "vwap"
   static void registerNamespace(const std::string& ns, ProviderFn fn) {
     std::lock_guard<std::mutex> lk(mx());

--- a/include/gma/engine/ConfigNamespaceRegistry.hpp
+++ b/include/gma/engine/ConfigNamespaceRegistry.hpp
@@ -16,6 +16,12 @@ using ConfigReaderFn = std::function<bool(std::string_view keyTail,
 
 class ConfigNamespaceRegistry {
 public:
+  // Tag instance — see EventTypeRegistry::singleton() for rationale.
+  static ConfigNamespaceRegistry& singleton() {
+    static ConfigNamespaceRegistry s;
+    return s;
+  }
+
   static bool registerNamespace(std::string prefix, ConfigReaderFn reader) {
     std::lock_guard lk(mx());
     auto [it, ok] = map().emplace(std::move(prefix), std::move(reader));

--- a/include/gma/engine/EngineRegistries.hpp
+++ b/include/gma/engine/EngineRegistries.hpp
@@ -3,26 +3,53 @@
 namespace boost::asio { class io_context; }
 
 namespace gma {
+class AtomicProviderRegistry;
 class AtomicStore;
 class Dispatcher;
+class FunctionMap;
 namespace rt   { class ThreadPool; class ShutdownCoordinator; }
-namespace util { struct Config; }
+namespace util { class Config; class Logger; }
 }
 
 namespace gma::engine {
 
-// Handle passed to every IConnector::registerWith() call. Bundles the
-// long-lived engine pieces a connector may need during boot: config, thread
-// pool, store, dispatcher, shutdown coordinator, and the ASIO io_context used
-// for socket work. Static registries (NodeTypeRegistry, FunctionMap, etc.) are
-// accessed through their own singletons and not re-exposed here.
+class ConfigNamespaceRegistry;
+class EventComputerRegistry;
+class EventTypeRegistry;
+class IngressRegistry;
+class NodeTypeRegistry;
+
+// Handle passed to every IConnector::registerWith() call. Bundles every
+// long-lived engine piece a connector may need during boot.
+//
+// The first six fields (cfg / pool / store / dispatcher / shutdown / io)
+// are real per-instance objects owned by main() (or a test fixture).
+//
+// The next eight fields point at the engine's extension-point registries.
+// Most of those registries store all state in private static maps and only
+// expose static methods; the pointer is then "informational" — connectors
+// may dereference it to call static methods through the singleton tag, or
+// invoke the static methods directly. Either is correct. FunctionMap and
+// Logger have real per-instance state and are pointers to their existing
+// process-wide singletons.
 struct EngineRegistries {
+  // ---- Per-instance engine objects ----
   const util::Config*        cfg        { nullptr };
   rt::ThreadPool*            pool       { nullptr };
   AtomicStore*               store      { nullptr };
-  Dispatcher*          dispatcher { nullptr };
+  Dispatcher*                dispatcher { nullptr };
   rt::ShutdownCoordinator*   shutdown   { nullptr };
   boost::asio::io_context*   io         { nullptr };
+
+  // ---- Engine extension-point registries (singletons) ----
+  EventTypeRegistry*         events     { nullptr };
+  EventComputerRegistry*     computers  { nullptr };
+  NodeTypeRegistry*          nodes      { nullptr };
+  IngressRegistry*           ingress    { nullptr };
+  ConfigNamespaceRegistry*   configNs   { nullptr };
+  AtomicProviderRegistry*    providers  { nullptr };
+  FunctionMap*               functions  { nullptr };
+  util::Logger*              log        { nullptr };
 };
 
 } // namespace gma::engine

--- a/include/gma/engine/EventComputerRegistry.hpp
+++ b/include/gma/engine/EventComputerRegistry.hpp
@@ -18,6 +18,12 @@ class EventComputerRegistry {
 public:
   using Factory = std::function<std::unique_ptr<IEventComputer>()>;
 
+  // Tag instance — see EventTypeRegistry::singleton() for rationale.
+  static EventComputerRegistry& singleton() {
+    static EventComputerRegistry s;
+    return s;
+  }
+
   // Register a factory for an event type. Multiple factories per type are
   // retained in registration order. Always succeeds.
   static void registerFactory(std::string eventType, Factory factory) {

--- a/include/gma/engine/EventTypeRegistry.hpp
+++ b/include/gma/engine/EventTypeRegistry.hpp
@@ -15,6 +15,14 @@ struct EventSchema {
 
 class EventTypeRegistry {
 public:
+  // Tag instance — registry methods are static, so the singleton is purely a
+  // handle for EngineRegistries to expose. All real storage lives in the
+  // private static map below.
+  static EventTypeRegistry& singleton() {
+    static EventTypeRegistry s;
+    return s;
+  }
+
   static bool registerEvent(EventSchema schema) {
     std::lock_guard lk(mx());
     auto key = schema.name;

--- a/include/gma/engine/IngressRegistry.hpp
+++ b/include/gma/engine/IngressRegistry.hpp
@@ -34,6 +34,12 @@ using IngressFactory = std::function<std::unique_ptr<IIngressSource>(
 
 class IngressRegistry {
 public:
+  // Tag instance — see EventTypeRegistry::singleton() for rationale.
+  static IngressRegistry& singleton() {
+    static IngressRegistry s;
+    return s;
+  }
+
   static bool registerIngress(std::string kind, IngressFactory fn) {
     std::lock_guard lk(mx());
     auto [it, ok] = map().emplace(std::move(kind), std::move(fn));

--- a/include/gma/engine/NodeTypeRegistry.hpp
+++ b/include/gma/engine/NodeTypeRegistry.hpp
@@ -22,6 +22,12 @@ using NodeBuilderFn = std::function<std::shared_ptr<INode>(
 
 class NodeTypeRegistry {
 public:
+  // Tag instance — see EventTypeRegistry::singleton() for rationale.
+  static NodeTypeRegistry& singleton() {
+    static NodeTypeRegistry s;
+    return s;
+  }
+
   static bool registerNodeType(std::string name, NodeBuilderFn fn) {
     std::lock_guard lk(mx());
     auto [it, ok] = map().emplace(std::move(name), std::move(fn));

--- a/include/gma/engine/Registries.hpp
+++ b/include/gma/engine/Registries.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+// Umbrella header for connector authors. Including this brings in IConnector,
+// EngineRegistries, and every engine extension-point registry so a connector
+// implementation can write a single include instead of seven.
+//
+// Engine code should still include the specific headers it needs.
+
+#include "gma/engine/IConnector.hpp"
+#include "gma/engine/EngineRegistries.hpp"
+#include "gma/engine/EventTypeRegistry.hpp"
+#include "gma/engine/EventComputerRegistry.hpp"
+#include "gma/engine/NodeTypeRegistry.hpp"
+#include "gma/engine/IngressRegistry.hpp"
+#include "gma/engine/ConfigNamespaceRegistry.hpp"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,10 +11,12 @@
 // -------- Engine --------
 #include "gma/AtomicStore.hpp"
 #include "gma/ExecutionContext.hpp"
+#include "gma/FunctionMap.hpp"
 #include "gma/FunctionRegistry.hpp"
 #include "gma/Dispatcher.hpp"
 #include "gma/NodeRegistry.hpp"
-#include "gma/engine/EngineRegistries.hpp"
+#include "gma/atomic/AtomicProviderRegistry.hpp"
+#include "gma/engine/Registries.hpp"
 #include "gma/rt/ThreadPool.hpp"
 #include "gma/runtime/ShutdownCoordinator.hpp"
 #include "gma/server/WebSocketServer.hpp"
@@ -141,7 +143,15 @@ int main(int argc, char* argv[]) {
   //    order. With one connector today the reverse-order is trivial; the
   //    pattern is future-proof.
   gma::engine::EngineRegistries regs{
-    &cfg, gma::gThreadPool.get(), store.get(), dispatcher.get(), &shutdown, &ioc
+    &cfg, gma::gThreadPool.get(), store.get(), dispatcher.get(), &shutdown, &ioc,
+    &gma::engine::EventTypeRegistry::singleton(),
+    &gma::engine::EventComputerRegistry::singleton(),
+    &gma::engine::NodeTypeRegistry::singleton(),
+    &gma::engine::IngressRegistry::singleton(),
+    &gma::engine::ConfigNamespaceRegistry::singleton(),
+    &gma::AtomicProviderRegistry::singleton(),
+    &gma::FunctionMap::instance(),
+    &gma::util::logger(),
   };
   std::vector<gma::engine::IConnector*> connectors;
   gma::market::MarketConnector marketConnector;

--- a/tests/engine/EngineRegistriesShapeTest.cpp
+++ b/tests/engine/EngineRegistriesShapeTest.cpp
@@ -1,0 +1,74 @@
+// Pins the shape of the EngineRegistries struct: every field a connector
+// might rely on must be populatable. The composition root in main.cpp wires
+// real instances; this test wires every field with non-null pointers and
+// verifies they round-trip.
+
+#include "gma/AtomicStore.hpp"
+#include "gma/Dispatcher.hpp"
+#include "gma/FunctionMap.hpp"
+#include "gma/atomic/AtomicProviderRegistry.hpp"
+#include "gma/engine/Registries.hpp"
+#include "gma/rt/ThreadPool.hpp"
+#include "gma/runtime/ShutdownCoordinator.hpp"
+#include "gma/util/Config.hpp"
+#include "gma/util/Logger.hpp"
+
+#include <boost/asio/io_context.hpp>
+#include <gtest/gtest.h>
+
+using namespace gma;
+
+TEST(EngineRegistriesShapeTest, AllFieldsPopulatable) {
+  util::Config cfg;
+  rt::ThreadPool pool(1);
+  AtomicStore store;
+  Dispatcher dispatcher(&pool, &store);
+  rt::ShutdownCoordinator shutdown;
+  boost::asio::io_context ioc;
+
+  engine::EngineRegistries regs{
+    &cfg, &pool, &store, &dispatcher, &shutdown, &ioc,
+    &engine::EventTypeRegistry::singleton(),
+    &engine::EventComputerRegistry::singleton(),
+    &engine::NodeTypeRegistry::singleton(),
+    &engine::IngressRegistry::singleton(),
+    &engine::ConfigNamespaceRegistry::singleton(),
+    &AtomicProviderRegistry::singleton(),
+    &FunctionMap::instance(),
+    &util::logger(),
+  };
+
+  // Per-instance engine objects.
+  EXPECT_EQ(regs.cfg, &cfg);
+  EXPECT_EQ(regs.pool, &pool);
+  EXPECT_EQ(regs.store, &store);
+  EXPECT_EQ(regs.dispatcher, &dispatcher);
+  EXPECT_EQ(regs.shutdown, &shutdown);
+  EXPECT_EQ(regs.io, &ioc);
+
+  // Extension-point registries.
+  EXPECT_NE(regs.events,    nullptr);
+  EXPECT_NE(regs.computers, nullptr);
+  EXPECT_NE(regs.nodes,     nullptr);
+  EXPECT_NE(regs.ingress,   nullptr);
+  EXPECT_NE(regs.configNs,  nullptr);
+  EXPECT_NE(regs.providers, nullptr);
+  EXPECT_NE(regs.functions, nullptr);
+  EXPECT_NE(regs.log,       nullptr);
+
+  // Singleton accessors must return stable references across calls.
+  EXPECT_EQ(&engine::EventTypeRegistry::singleton(),     &engine::EventTypeRegistry::singleton());
+  EXPECT_EQ(&engine::EventComputerRegistry::singleton(), &engine::EventComputerRegistry::singleton());
+  EXPECT_EQ(&engine::NodeTypeRegistry::singleton(),      &engine::NodeTypeRegistry::singleton());
+  EXPECT_EQ(&engine::IngressRegistry::singleton(),       &engine::IngressRegistry::singleton());
+  EXPECT_EQ(&engine::ConfigNamespaceRegistry::singleton(),&engine::ConfigNamespaceRegistry::singleton());
+  EXPECT_EQ(&AtomicProviderRegistry::singleton(),        &AtomicProviderRegistry::singleton());
+}
+
+TEST(EngineRegistriesShapeTest, FieldCountIs14) {
+  // Guard against accidental field removal: sizeof should equal 14 pointers.
+  // (Six per-instance + eight registry pointers, all 8-byte on x86_64.)
+  static_assert(sizeof(engine::EngineRegistries) == 14 * sizeof(void*),
+                "EngineRegistries must carry exactly 14 pointer-sized fields");
+  SUCCEED();
+}


### PR DESCRIPTION
Stacked on top of #2 (phase 1).

## Summary
- `EngineRegistries` gains 8 pointer fields covering every engine extension-point registry: `events`, `computers`, `nodes`, `ingress`, `configNs`, `providers`, `functions`, `log` (alongside the existing 6 per-instance fields, total = 14).
- Static-only registries (`EventTypeRegistry`, `EventComputerRegistry`, `NodeTypeRegistry`, `IngressRegistry`, `ConfigNamespaceRegistry`, `AtomicProviderRegistry`) gain a `singleton()` accessor so the field has a stable instance to point at; methods remain static, so the pointer is informational.
- New `engine/Registries.hpp` umbrella include — connector authors can replace seven separate includes with one.
- `main.cpp` populates all 14 fields when constructing the `EngineRegistries` handed to `MarketConnector`.
- New `EngineRegistriesShapeTest` pins the field set (every field populatable, singletons stable, `static_assert` on `sizeof`).

## Linear
Closes ENC-55, ENC-56, ENC-57. Satisfies AC3 (ENC-72).

## Test plan
- [x] `ctest --output-on-failure` — 367/367 pass (+2 shape test)
- [x] `static_assert` on `sizeof(EngineRegistries) == 14 * sizeof(void*)` holds

🤖 Generated with [Claude Code](https://claude.com/claude-code)