### PR TITLE
[connector-lifecycle phase 3] Dispatcher reads computers from registry (lazy cache)

### DIFF
--- a/connectors/market/src/MarketConnector.cpp
+++ b/connectors/market/src/MarketConnector.cpp
@@ -3,6 +3,7 @@
 #include <cstdlib>
 #include <limits>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <utility>
 
@@ -11,6 +12,7 @@
 #include "gma/MarketTA.hpp"
 #include "gma/atomic/AtomicProviderRegistry.hpp"
 #include "gma/book/OrderBookManager.hpp"
+#include "gma/engine/EventComputerRegistry.hpp"
 #include "gma/engine/IEventComputer.hpp"
 #include "gma/feed/IFeedAdapter.hpp"
 #include "gma/feed/ItchAdapter.hpp"
@@ -39,12 +41,24 @@ void MarketConnector::stop() noexcept {
 }
 
 void MarketConnector::installDefaults() {
-  Dispatcher::setDefaultComputerFactory(
-    [](const util::Config& cfg) {
-      std::vector<std::unique_ptr<engine::IEventComputer>> out;
-      out.push_back(std::make_unique<MarketTickComputer>(cfg));
-      return out;
-    });
+  // Register the market tick computer factory with the engine. Every
+  // Dispatcher built after this call will lazily pick up a fresh
+  // MarketTickComputer the first time it sees a "tick" event.
+  //
+  // EventComputerRegistry::registerFactory is additive, but main.cpp +
+  // registerWith() both invoke this — std::call_once preserves the
+  // "safe to call multiple times" idempotent-replace semantics.
+  //
+  // The factory receives each Dispatcher's own util::Config so per-Dispatcher
+  // tuning (sourceProfile, taHistoryMax, …) is honored. Phase 4 will move
+  // this registration into registerWith() where reg.cfg is also available.
+  static std::once_flag once;
+  std::call_once(once, [] {
+    engine::EventComputerRegistry::registerFactory("tick",
+      [](const util::Config& cfg) {
+        return std::make_unique<MarketTickComputer>(cfg);
+      });
+  });
 }
 
 void MarketConnector::registerWith(engine::EngineRegistries& reg) {

--- a/include/gma/Dispatcher.hpp
+++ b/include/gma/Dispatcher.hpp
@@ -4,6 +4,7 @@
 #include <functional>
 #include <map>
 #include <memory>
+#include <mutex>
 #include <shared_mutex>
 #include <string>
 #include <unordered_map>
@@ -13,6 +14,7 @@
 #include "gma/FunctionMap.hpp"
 #include "gma/Event.hpp"
 #include "gma/StreamValue.hpp"
+#include "gma/engine/EventComputerRegistry.hpp"
 #include "gma/engine/IEventComputer.hpp"
 #include "gma/nodes/INode.hpp"
 #include "gma/rt/ThreadPool.hpp"
@@ -26,30 +28,20 @@ namespace gma {
  * can be recomputed on each update.
  *
  * Domain-specific computations (market TA, order-book derivations, …) live in
- * IEventComputer implementations owned by the dispatcher. They are invoked on
- * every onTick BEFORE the raw-field notify loop runs. Computers may call
- * notifyListeners() to deliver their computed values to subscribers.
- *
- * Renamed to engine::Dispatcher in a later step — this class will become the
- * generic routing layer. Until then, the market tick computer is wired in by
- * the constructor for backward compatibility with existing call sites.
+ * IEventComputer implementations sourced from EventComputerRegistry. The
+ * dispatcher caches per-type computer instances lazily on first event of
+ * each type, so late-registered factories are picked up automatically.
+ * Computers may call notifyListeners() to deliver values to subscribers.
  */
 class Dispatcher {
 public:
   Dispatcher(gma::rt::ThreadPool* threadPool, AtomicStore* store,
                    const util::Config& cfg = util::Config{});
 
-  // Factory hook installed by the market side at boot. Every new dispatcher
-  // calls this (if installed) to populate its computers list — lets the engine
-  // header avoid any market include while preserving existing construction
-  // call sites. Removed in Step 8 when IConnector formalization lands.
-  using DefaultComputerFactory =
-      std::function<std::vector<std::unique_ptr<engine::IEventComputer>>(
-          const util::Config&)>;
-  static void setDefaultComputerFactory(DefaultComputerFactory f);
-
   // Append an event computer after construction. Primarily used by tests and
-  // code paths that want TA without depending on the default-factory hook.
+  // code paths that want a computer without going through
+  // EventComputerRegistry. Connectors should prefer the registry path so the
+  // dispatcher's per-type cache picks them up automatically.
   void addComputer(std::unique_ptr<engine::IEventComputer> computer);
 
   void registerListener(const std::string& symbol,
@@ -89,9 +81,20 @@ private:
       std::map<std::string, std::vector<std::shared_ptr<INode>>>
   > _listeners;
 
-  // Domain-specific computers (e.g. MarketTickComputer for TA). Constructed in
-  // the ctor; invoked on every onTick in registration order.
+  // Computers added explicitly via addComputer(). Filtered by eventType() on
+  // every onTick. Kept separate from the registry-driven cache so test code
+  // can inject computers without touching the global EventComputerRegistry.
   std::vector<std::unique_ptr<engine::IEventComputer>> _computers;
+
+  // Per-type cache of computers built from EventComputerRegistry. Populated
+  // lazily on first event of a given type — every `onTick` for an unseen
+  // type calls EventComputerRegistry::createAll(type) and caches the result
+  // for the lifetime of this Dispatcher. Late-registered factories are
+  // therefore picked up on the first event of their type.
+  std::unordered_map<std::string,
+                     std::vector<std::unique_ptr<engine::IEventComputer>>>
+                                          _computersByType;
+  mutable std::mutex                      _computerCacheMx;
 
   mutable std::shared_mutex _histMutex;
   mutable std::shared_mutex _listenerMutex;

--- a/include/gma/engine/EventComputerRegistry.hpp
+++ b/include/gma/engine/EventComputerRegistry.hpp
@@ -5,18 +5,26 @@
 #include <string>
 #include <string_view>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 #include "gma/engine/IEventComputer.hpp"
+#include "gma/util/Config.hpp"
 
 namespace gma::engine {
 
 // Registry of **factories** that produce per-dispatcher IEventComputer instances.
-// Dispatchers call createAll() during construction to get their own fresh set of
-// computers — this isolates state (e.g. per-symbol TA histories) between
-// dispatcher instances, which matters in tests that spin up multiple dispatchers.
+// Dispatchers call createAll() on first event of each type to get their own
+// fresh set of computers — this isolates state (e.g. per-symbol TA histories)
+// between dispatcher instances, which matters in tests that spin up multiple
+// dispatchers.
+//
+// Factories receive the dispatcher's util::Config so connector-supplied
+// computers (e.g. MarketTickComputer) can honor per-dispatcher tuning.
+// Connectors that do not need the config can register a no-arg factory via
+// the convenience overload below.
 class EventComputerRegistry {
 public:
-  using Factory = std::function<std::unique_ptr<IEventComputer>()>;
+  using Factory = std::function<std::unique_ptr<IEventComputer>(const util::Config&)>;
 
   // Tag instance — see EventTypeRegistry::singleton() for rationale.
   static EventComputerRegistry& singleton() {
@@ -24,18 +32,28 @@ public:
     return s;
   }
 
-  // Register a factory for an event type. Multiple factories per type are
-  // retained in registration order. Always succeeds.
+  // Register a config-aware factory for an event type. Multiple factories per
+  // type are retained in registration order. Always succeeds.
   static void registerFactory(std::string eventType, Factory factory) {
     if (!factory) return;
     std::lock_guard lk(mx());
     map()[std::move(eventType)].push_back(std::move(factory));
   }
 
+  // Convenience overload: register a no-arg factory. The dispatcher's cfg is
+  // ignored. Useful for tests and computers whose construction is configless.
+  static void registerFactory(std::string eventType,
+                              std::function<std::unique_ptr<IEventComputer>()> nullary) {
+    if (!nullary) return;
+    registerFactory(std::move(eventType),
+                    [f = std::move(nullary)](const util::Config&) { return f(); });
+  }
+
   // Instantiate every registered computer for the given event type, in
-  // registration order. Each call yields fresh instances.
+  // registration order. Each call yields fresh instances. Factories receive
+  // the supplied cfg (default-constructed if omitted).
   static std::vector<std::unique_ptr<IEventComputer>>
-  createAll(std::string_view eventType) {
+  createAll(std::string_view eventType, const util::Config& cfg = util::Config{}) {
     std::vector<Factory> factoriesCopy;
     {
       std::lock_guard lk(mx());
@@ -46,7 +64,7 @@ public:
     std::vector<std::unique_ptr<IEventComputer>> out;
     out.reserve(factoriesCopy.size());
     for (auto& f : factoriesCopy) {
-      if (auto c = f()) out.push_back(std::move(c));
+      if (auto c = f(cfg)) out.push_back(std::move(c));
     }
     return out;
   }

--- a/src/core/Dispatcher.cpp
+++ b/src/core/Dispatcher.cpp
@@ -7,25 +7,6 @@
 
 using namespace gma;
 
-namespace {
-// Guarded singleton for the default computer factory. Set once at boot by
-// whichever side owns market-specific computers (main.cpp / test bootstrap /
-// a future MarketConnector::registerWith); read from every dispatcher ctor.
-std::mutex& hookMutex() {
-  static std::mutex m;
-  return m;
-}
-Dispatcher::DefaultComputerFactory& hook() {
-  static Dispatcher::DefaultComputerFactory f;
-  return f;
-}
-} // namespace
-
-void Dispatcher::setDefaultComputerFactory(DefaultComputerFactory f) {
-  std::lock_guard<std::mutex> lk(hookMutex());
-  hook() = std::move(f);
-}
-
 void Dispatcher::addComputer(std::unique_ptr<engine::IEventComputer> c) {
   if (c) _computers.push_back(std::move(c));
 }
@@ -39,19 +20,7 @@ Dispatcher::Dispatcher(rt::ThreadPool* threadPool,
   , _maxHistory(static_cast<std::size_t>(std::max(1, cfg.taHistoryMax)))
   , _maxSymbols(static_cast<std::size_t>(std::max(1, cfg.maxSymbols)))
   , _maxFieldsPerSymbol(static_cast<std::size_t>(std::max(1, cfg.maxFieldsPerSymbol)))
-{
-  DefaultComputerFactory installed;
-  {
-    std::lock_guard<std::mutex> lk(hookMutex());
-    installed = hook();
-  }
-  if (installed) {
-    auto computers = installed(cfg);
-    for (auto& c : computers) {
-      if (c) _computers.push_back(std::move(c));
-    }
-  }
-}
+{}
 
 void Dispatcher::registerListener(const std::string& symbol,
                                         const std::string& field,
@@ -80,16 +49,33 @@ void Dispatcher::unregisterListener(const std::string& symbol,
 void Dispatcher::onTick(const Event& tick) {
   if (tick.symbol.empty() || !tick.payload) return;
 
-  // Invoke every domain computer whose eventType matches this event's type
-  // (defaults to "tick"). TA writes to the store and may notifyListeners on
-  // computed keys (sma_5, rsi_14, …).
-  if (!_computers.empty()) {
-    engine::ComputeContext ctx{ _store, this, _threadPool };
-    for (auto& c : _computers) {
-      if (!c) continue;
-      if (c->eventType() != tick.type) continue;
-      c->compute(tick, ctx);
+  engine::ComputeContext ctx{ _store, this, _threadPool };
+
+  // Per-type cache fed from EventComputerRegistry. First event of a given
+  // type instantiates the registered factories; subsequent events reuse the
+  // cached instances. Late-registered factories are picked up the first time
+  // an event of their type arrives.
+  std::vector<engine::IEventComputer*> typedComputers;
+  {
+    std::lock_guard<std::mutex> lk(_computerCacheMx);
+    auto it = _computersByType.find(tick.type);
+    if (it == _computersByType.end()) {
+      auto fresh = engine::EventComputerRegistry::createAll(tick.type, _cfg);
+      it = _computersByType.emplace(tick.type, std::move(fresh)).first;
     }
+    typedComputers.reserve(it->second.size());
+    for (auto& c : it->second) typedComputers.push_back(c.get());
+  }
+  for (auto* c : typedComputers) {
+    if (c) c->compute(tick, ctx);
+  }
+
+  // Computers added directly via addComputer() — kept for tests and code
+  // paths that want to inject without the global registry.
+  for (auto& c : _computers) {
+    if (!c) continue;
+    if (c->eventType() != tick.type) continue;
+    c->compute(tick, ctx);
   }
 
   // Collect (field, listener) pairs for this symbol under the listener lock.

--- a/tests/engine/EventComputerCacheTest.cpp
+++ b/tests/engine/EventComputerCacheTest.cpp
@@ -1,0 +1,111 @@
+// Pins the lazy-cache contract in Dispatcher::onTick: a Dispatcher constructed
+// before a factory is registered must still pick up that factory the first
+// time it sees an event of that type. This is the single biggest invariant
+// the EventComputerRegistry path provides over the old DefaultComputerFactory
+// hook (which only ran in the ctor).
+//
+// Each test uses a unique event type so registry pollution doesn't leak
+// between tests; we never call EventComputerRegistry::clear() (which would
+// wipe the test-bootstrap's "tick" factory and break unrelated tests).
+
+#include "gma/AtomicStore.hpp"
+#include "gma/Dispatcher.hpp"
+#include "gma/Event.hpp"
+#include "gma/engine/EventComputerRegistry.hpp"
+#include "gma/engine/IEventComputer.hpp"
+#include "gma/rt/ThreadPool.hpp"
+#include "gma/util/Config.hpp"
+
+#include <gtest/gtest.h>
+#include <atomic>
+#include <memory>
+#include <string>
+#include <rapidjson/document.h>
+
+using namespace gma;
+
+namespace {
+
+class CountingComputer final : public engine::IEventComputer {
+public:
+  explicit CountingComputer(std::string type, std::atomic<int>* invocations)
+    : _type(std::move(type)), _invocations(invocations) {}
+  std::string_view eventType() const override { return _type; }
+  void compute(const Event&, engine::ComputeContext&) override {
+    if (_invocations) _invocations->fetch_add(1);
+  }
+private:
+  std::string _type;
+  std::atomic<int>* _invocations;
+};
+
+Event makeEvent(const std::string& type, const std::string& sym) {
+  Event e;
+  e.type    = type;
+  e.symbol  = sym;
+  e.payload = std::make_shared<rapidjson::Document>();
+  e.payload->SetObject();
+  return e;
+}
+
+// Each test gets a unique event-type string so factories don't bleed across
+// tests via the (process-wide) EventComputerRegistry singleton.
+std::string uniqueType(const char* tag) {
+  static std::atomic<int> counter{0};
+  return std::string("cache.test.") + tag + "." + std::to_string(counter.fetch_add(1));
+}
+
+} // namespace
+
+TEST(EventComputerCacheTest, LateRegisteredFactoryIsPickedUp) {
+  rt::ThreadPool pool(1);
+  AtomicStore store;
+  Dispatcher dispatcher(&pool, &store);
+
+  // Dispatcher is fully constructed BEFORE we register the factory.
+  // Old behavior: the dispatcher's ctor took a snapshot via the static hook,
+  // so anything registered after construction would never fire. New behavior:
+  // the per-type cache is built lazily on first event, so this must work.
+  const std::string evType = uniqueType("late");
+  std::atomic<int> factoryCalls{0};
+  std::atomic<int> invocations{0};
+
+  engine::EventComputerRegistry::registerFactory(evType, [&] {
+    factoryCalls.fetch_add(1);
+    return std::make_unique<CountingComputer>(evType, &invocations);
+  });
+
+  EXPECT_EQ(factoryCalls.load(), 0);  // factory not invoked yet — lazy.
+  dispatcher.onTick(makeEvent(evType, "X"));
+  EXPECT_EQ(factoryCalls.load(), 1);  // first event of type → factory called.
+  EXPECT_EQ(invocations.load(), 1);
+
+  dispatcher.onTick(makeEvent(evType, "X"));
+  EXPECT_EQ(factoryCalls.load(), 1);  // second event → cache hit, no new factory call.
+  EXPECT_EQ(invocations.load(), 2);   // same instance fired twice.
+}
+
+TEST(EventComputerCacheTest, EachDispatcherGetsFreshInstances) {
+  rt::ThreadPool pool(1);
+  AtomicStore store;
+
+  const std::string evType = uniqueType("fresh");
+  std::atomic<int> factoryCalls{0};
+  std::atomic<int> invocations{0};
+
+  engine::EventComputerRegistry::registerFactory(evType, [&] {
+    factoryCalls.fetch_add(1);
+    return std::make_unique<CountingComputer>(evType, &invocations);
+  });
+
+  Dispatcher d1(&pool, &store);
+  Dispatcher d2(&pool, &store);
+
+  d1.onTick(makeEvent(evType, "X"));
+  d2.onTick(makeEvent(evType, "X"));
+
+  // Each Dispatcher's first event of the type triggers an independent
+  // factory call → two fresh instances, no shared state.
+  EXPECT_EQ(factoryCalls.load(), 2);
+  EXPECT_EQ(invocations.load(), 2);
+}

--- a/tests/engine/RegistriesTest.cpp
+++ b/tests/engine/RegistriesTest.cpp
@@ -125,7 +125,7 @@ TEST(EventComputerRegistryTest, CreateAllOnMissingTypeReturnsEmpty) {
 
 TEST(EventComputerRegistryTest, NullFactoryIgnored) {
   const std::string t = "__test_cr_null__";
-  EventComputerRegistry::registerFactory(t, nullptr);
+  EventComputerRegistry::registerFactory(t, EventComputerRegistry::Factory{});
   EXPECT_EQ(EventComputerRegistry::factoryCount(t), 0u);
 }
 


### PR DESCRIPTION
Stacked on top of #3 (phase 2). Carries the system-behavior change of the project.

## Summary
**Engine**
- Delete `Dispatcher::DefaultComputerFactory` + `setDefaultComputerFactory` and the anon-namespace hook singleton; the eager ctor pull is gone.
- `Dispatcher` gains a per-instance `_computersByType` cache + `_computerCacheMx`. `onTick` lazily populates the cache on first event of each type by calling `EventComputerRegistry::createAll(type, _cfg)`. **Late-registered factories are picked up on the first event of their type.**
- `Dispatcher::addComputer` retained for tests / direct injection paths.

**EventComputerRegistry**
- Factory signature gains a `const util::Config&` argument so the dispatcher's cfg flows through to per-instance computers (`sourceProfile`, `taHistoryMax`, …). `createAll(type, cfg)` defaults to an empty Config.
- New no-arg `registerFactory` overload wraps configless factories — preserves every existing test-side call site.

**Market connector**
- `installDefaults` registers the `tick` factory via `EventComputerRegistry::registerFactory`; the factory builds a `MarketTickComputer` from the dispatcher's cfg. `std::call_once` preserves the historical \"safe to call multiple times\" idempotent-replace contract.

**Tests**
- New `EventComputerCacheTest` pins the lazy-cache contract: a Dispatcher constructed BEFORE its factory is registered still picks the factory up on the first event of that type; each Dispatcher gets fresh per-instance computers.

## Linear
Closes ENC-58, ENC-59, ENC-60, ENC-61. Satisfies AC2 (ENC-71).

## Test plan
- [x] `ctest --output-on-failure` — 369/369 pass
- [x] `bench_dispatcher --benchmark_min_time=2s` — **562.539k items/s** vs baseline 481.369k (improvement, no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)