### PR TITLE
[connector-lifecycle phase 4] connector full lifecycle migration; installDefaults removed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,7 @@ See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for the full picture including 
 - Runtime config: INI-style key=value files (see `src/util/gma.conf`)
 - Prefer lock-free / fine-grained locking (shared_mutex, SPSCQueue)
 - Test files named `<Component>Test.cpp` under `tests/<category>/`; the gtest binary is a single `gma_tests` executable
+- Connectors implement the strict `IConnector` lifecycle: `registerWith()` allocates and registers (no live sockets/timers), `start()` brings sources online, `stop()` noexcept tears down in reverse order. The composition root drives all three; never wire your own `ShutdownCoordinator` step from inside a connector.
 
 ## Configuration
 

--- a/connectors/market/include/gma/market/MarketConnector.hpp
+++ b/connectors/market/include/gma/market/MarketConnector.hpp
@@ -16,34 +16,34 @@ class FeedServer;
 namespace gma::market {
 
 // The market connector owns everything market-specific: order book engine,
-// TA tick computer (via DefaultComputerFactory hook), "ob.*" atomic provider
-// namespace, TCP FeedServer, and external WsFeedClients driven by ItchAdapter.
+// TA tick computer (registered with EventComputerRegistry), "ob.*" atomic
+// provider namespace, TCP FeedServer, and external WsFeedClients driven by
+// ItchAdapter.
 //
-// Usage in main():
-//   MarketConnector::installDefaults();          // install TA computer hook
-//   // ... construct engine pieces (pool/store/dispatcher/ioc) ...
+// Lifecycle (driven by the composition root):
 //   MarketConnector connector;
-//   EngineRegistries regs{ &cfg, pool, store, dispatcher, &shutdown, &ioc };
-//   connector.registerWith(regs);                // everything else
+//   connector.registerWith(regs);   // construct + register; nothing running
+//   connector.start();              // run the feed server + WS clients
+//   ...
+//   connector.stop();               // reverse-order teardown (idempotent)
 class MarketConnector final : public engine::IConnector {
 public:
-  // Install the Dispatcher DefaultComputerFactory hook so every
-  // dispatcher constructed after this call gets its own MarketTickComputer.
-  // Safe to call multiple times (idempotent replace).
-  static void installDefaults();
-
   MarketConnector();
   ~MarketConnector() override;
 
   std::string_view name() const override { return "market"; }
 
-  // Full market boot: construct OrderBookManager, wire its provider into the
-  // AtomicProviderRegistry under "ob.*", start the TCP FeedServer on
-  // cfg.feedPort, spin up configured WsFeedClients, and register all
-  // shutdown steps on reg.shutdown. Returns with the servers running inside
-  // reg.io (which the caller drives via io.run()).
+  // Construct OrderBookManager, wire its provider into AtomicProviderRegistry
+  // under "ob.*", construct (do NOT run) the TCP FeedServer on cfg.feedPort,
+  // construct (do NOT start) configured WsFeedClients, and register the
+  // "tick" event-computer factory.
   void registerWith(engine::EngineRegistries& reg) override;
+
+  // Run the feed server + WS feed clients. Failures on individual feed
+  // clients are logged and do not abort the rest.
   void start() override;
+
+  // Reverse-order teardown. Idempotent: a second call is a no-op.
   void stop() noexcept override;
 
 private:

--- a/connectors/market/include/gma/server/FeedServer.hpp
+++ b/connectors/market/include/gma/server/FeedServer.hpp
@@ -46,6 +46,7 @@ private:
   boost::asio::io_context& ioc_;
   tcp::acceptor            acceptor_;
   std::atomic<bool>        accepting_{false};
+  unsigned short           port_{0};
 
   Dispatcher*        dispatcher_; // not owned
   OrderBookManager*        obManager_{nullptr}; // not owned

--- a/connectors/market/src/MarketConnector.cpp
+++ b/connectors/market/src/MarketConnector.cpp
@@ -3,8 +3,8 @@
 #include <cstdlib>
 #include <limits>
 #include <memory>
-#include <mutex>
 #include <optional>
+#include <stdexcept>
 #include <utility>
 
 #include "gma/AtomicStore.hpp"
@@ -19,7 +19,6 @@
 #include "gma/ob/FunctionalSnapshotSource.hpp"
 #include "gma/ob/ObMaterializer.hpp"
 #include "gma/ob/ObProvider.hpp"
-#include "gma/runtime/ShutdownCoordinator.hpp"
 #include "gma/server/FeedServer.hpp"
 #include "gma/util/Config.hpp"
 #include "gma/util/Logger.hpp"
@@ -30,49 +29,11 @@ namespace gma::market {
 MarketConnector::MarketConnector()  = default;
 MarketConnector::~MarketConnector() = default;
 
-void MarketConnector::start() {
-  // TODO: phase-4 — move feed run/client start/OB init from registerWith into
-  // start; mirror in stop.
-}
-
-void MarketConnector::stop() noexcept {
-  // TODO: phase-4 — reverse-order teardown of feed clients, feed server, and
-  // AtomicProviderRegistry.
-}
-
-void MarketConnector::installDefaults() {
-  // Register the market tick computer factory with the engine. Every
-  // Dispatcher built after this call will lazily pick up a fresh
-  // MarketTickComputer the first time it sees a "tick" event.
-  //
-  // EventComputerRegistry::registerFactory is additive, but main.cpp +
-  // registerWith() both invoke this — std::call_once preserves the
-  // "safe to call multiple times" idempotent-replace semantics.
-  //
-  // The factory receives each Dispatcher's own util::Config so per-Dispatcher
-  // tuning (sourceProfile, taHistoryMax, …) is honored. Phase 4 will move
-  // this registration into registerWith() where reg.cfg is also available.
-  static std::once_flag once;
-  std::call_once(once, [] {
-    engine::EventComputerRegistry::registerFactory("tick",
-      [](const util::Config& cfg) {
-        return std::make_unique<MarketTickComputer>(cfg);
-      });
-  });
-}
-
 void MarketConnector::registerWith(engine::EngineRegistries& reg) {
-  using util::logger;
-  using util::LogLevel;
-
-  if (!reg.cfg || !reg.shutdown || !reg.io || !reg.dispatcher) {
+  if (!reg.cfg || !reg.io || !reg.dispatcher || !reg.computers) {
     throw std::runtime_error("MarketConnector: incomplete EngineRegistries");
   }
   const util::Config& cfg = *reg.cfg;
-
-  // Ensure the computer factory hook is installed — safe no-op if the caller
-  // already did it, so consumers don't have to remember two steps.
-  installDefaults();
 
   // ---- Order book engine ----
   _obManager = std::make_shared<OrderBookManager>();
@@ -117,22 +78,20 @@ void MarketConnector::registerWith(engine::EngineRegistries& reg) {
       return obProvider->get(symbol, fullKey);
     });
 
-  reg.shutdown->registerStep("ob-provider-clear", 50, [] {
-    AtomicProviderRegistry::clear();
-  });
+  // Register the "tick" computer factory through the engine registry. Each
+  // Dispatcher's onTick lazily instantiates one MarketTickComputer per type
+  // using the dispatcher's own cfg, so per-Dispatcher tuning is honored.
+  reg.computers->registerFactory("tick",
+    [](const util::Config& dispatcherCfg) {
+      return std::make_unique<MarketTickComputer>(dispatcherCfg);
+    });
 
-  // ---- TCP FeedServer (market message schema) ----
+  // ---- TCP FeedServer (constructed, not started) ----
   const unsigned short feedPort = static_cast<unsigned short>(cfg.feedPort);
   _feedServer = std::make_unique<FeedServer>(*reg.io, reg.dispatcher,
                                              _obManager.get(), feedPort);
-  _feedServer->run();
 
-  FeedServer* feedPtr = _feedServer.get();
-  reg.shutdown->registerStep("feed-stop", 55, [feedPtr] {
-    try { feedPtr->stop(); } catch (...) {}
-  });
-
-  // ---- External WS feed clients ----
+  // ---- External WS feed clients (constructed, not started) ----
   auto effectiveFeeds = cfg.feeds;
   if (effectiveFeeds.empty()) {
     std::string feedUrl = cfg.feedUrl;
@@ -149,42 +108,62 @@ void MarketConnector::registerWith(engine::EngineRegistries& reg) {
     }
   }
 
-  for (std::size_t i = 0; i < effectiveFeeds.size(); ++i) {
-    const auto& fc = effectiveFeeds[i];
+  for (const auto& fc : effectiveFeeds) {
     if (fc.url.empty()) continue;
 
+    std::unique_ptr<feed::IFeedAdapter> adapter;
+    if (fc.adapter == "itch") {
+      adapter = std::make_unique<feed::ItchAdapter>();
+    } else {
+      // Default to ITCH; future: "generic", "coinbase", …
+      adapter = std::make_unique<feed::ItchAdapter>();
+    }
+
+    auto client = std::make_shared<ws::WsFeedClient>(
+        *reg.io, reg.dispatcher, _obManager.get(),
+        fc.url, std::move(adapter), fc.symbols);
+    _feedClients.push_back(std::move(client));
+  }
+}
+
+void MarketConnector::start() {
+  using util::logger;
+  using util::LogLevel;
+
+  if (_feedServer) {
+    _feedServer->run();
+  }
+
+  for (std::size_t i = 0; i < _feedClients.size(); ++i) {
+    auto& client = _feedClients[i];
+    if (!client) continue;
     try {
-      std::unique_ptr<feed::IFeedAdapter> adapter;
-      if (fc.adapter == "itch") {
-        adapter = std::make_unique<feed::ItchAdapter>();
-      } else {
-        // Default to ITCH; future: "generic", "coinbase", …
-        adapter = std::make_unique<feed::ItchAdapter>();
-      }
-
-      auto client = std::make_shared<ws::WsFeedClient>(
-          *reg.io, reg.dispatcher, _obManager.get(),
-          fc.url, std::move(adapter), fc.symbols);
       client->start();
-      _feedClients.push_back(client);
-
       logger().log(LogLevel::Info, "feed_client.started",
-                   {{"url", fc.url}, {"adapter", fc.adapter},
-                    {"index", std::to_string(i)}});
+                   {{"index", std::to_string(i)}});
     } catch (const std::exception& ex) {
       logger().log(LogLevel::Error, "feed_client.start_failed",
-                   {{"err", ex.what()}, {"url", fc.url},
-                    {"index", std::to_string(i)}});
+                   {{"err", ex.what()}, {"index", std::to_string(i)}});
     }
   }
-  for (auto& fc : _feedClients) {
-    auto weak = std::weak_ptr<ws::WsFeedClient>(fc);
-    reg.shutdown->registerStep("feed-ws-stop", 56, [weak] {
-      if (auto s = weak.lock()) {
-        try { s->stop(); } catch (...) {}
-      }
-    });
+}
+
+void MarketConnector::stop() noexcept {
+  // Reverse of start / registerWith. Old per-step priorities preserved as
+  // comments so reviewers can map the old ShutdownCoordinator order to here.
+  for (auto& fc : _feedClients) {           // was priority 56 (feed-ws-stop)
+    if (!fc) continue;
+    try { fc->stop(); } catch (...) {}
   }
+  _feedClients.clear();
+
+  if (_feedServer) {                        // was priority 55 (feed-stop)
+    try { _feedServer->stop(); } catch (...) {}
+    _feedServer.reset();
+  }
+
+  try { AtomicProviderRegistry::clear(); }  // was priority 50 (ob-provider-clear)
+  catch (...) {}
 }
 
 } // namespace gma::market

--- a/connectors/market/src/server/FeedServer.cpp
+++ b/connectors/market/src/server/FeedServer.cpp
@@ -345,10 +345,20 @@ FeedServer::FeedServer(boost::asio::io_context& ioc,
   : ioc_(ioc),
     acceptor_(ioc),
     dispatcher_(dispatcher),
-    obManager_(obManager)
+    obManager_(obManager),
+    port_(port)
 {
+  // Constructor is intentionally side-effect-free — no bind, no listen.
+  // run() opens the socket so callers can construct ahead of start (per
+  // the IConnector lifecycle: registerWith allocates, start brings up).
+}
+
+void FeedServer::run() {
+  bool expected = false;
+  if (!accepting_.compare_exchange_strong(expected, true)) return;
+
   boost::system::error_code ec;
-  tcp::endpoint ep{tcp::v4(), port};
+  tcp::endpoint ep{tcp::v4(), port_};
 
   acceptor_.open(ep.protocol(), ec);
   if (ec) throw boost::system::system_error(ec);
@@ -361,11 +371,7 @@ FeedServer::FeedServer(boost::asio::io_context& ioc,
 
   acceptor_.listen(boost::asio::socket_base::max_listen_connections, ec);
   if (ec) throw boost::system::system_error(ec);
-}
 
-void FeedServer::run() {
-  bool expected = false;
-  if (!accepting_.compare_exchange_strong(expected, true)) return;
   doAccept();
 }
 

--- a/connectors/synthetic/include/gma/synthetic/SyntheticConnector.hpp
+++ b/connectors/synthetic/include/gma/synthetic/SyntheticConnector.hpp
@@ -10,6 +10,10 @@
 #include "gma/engine/IConnector.hpp"
 #include "gma/engine/IEventComputer.hpp"
 
+namespace gma {
+class Dispatcher;
+}
+
 namespace gma::synthetic {
 
 // Demo connector that proves the engine/connector boundary: it lives entirely
@@ -37,6 +41,7 @@ public:
 private:
   Options                               _opts;
   std::unique_ptr<boost::asio::steady_timer> _timer;
+  Dispatcher*                           _dispatcher { nullptr };
   std::uint64_t                         _counter { 0 };
 };
 

--- a/connectors/synthetic/src/SyntheticConnector.cpp
+++ b/connectors/synthetic/src/SyntheticConnector.cpp
@@ -4,6 +4,7 @@
 #include <cmath>
 #include <functional>
 #include <memory>
+#include <stdexcept>
 
 #include <boost/asio/io_context.hpp>
 #include <boost/asio/steady_timer.hpp>
@@ -12,7 +13,7 @@
 #include "gma/AtomicStore.hpp"
 #include "gma/Dispatcher.hpp"
 #include "gma/Event.hpp"
-#include "gma/runtime/ShutdownCoordinator.hpp"
+#include "gma/engine/EventComputerRegistry.hpp"
 
 namespace gma::synthetic {
 
@@ -34,36 +35,34 @@ SyntheticConnector::SyntheticConnector() = default;
 SyntheticConnector::SyntheticConnector(Options opts) : _opts(std::move(opts)) {}
 SyntheticConnector::~SyntheticConnector() = default;
 
-void SyntheticConnector::start() {
-  // TODO: phase-4 — move timer arm (expires_after + async_wait) here.
-}
-
-void SyntheticConnector::stop() noexcept {
-  // TODO: phase-4 — cancel the timer here (currently done via the
-  // synthetic-timer-cancel ShutdownCoordinator step).
-}
-
 void SyntheticConnector::registerWith(engine::EngineRegistries& reg) {
-  if (!reg.dispatcher || !reg.io) {
+  if (!reg.dispatcher || !reg.io || !reg.computers) {
     throw std::runtime_error("SyntheticConnector: incomplete EngineRegistries");
   }
 
-  // Hand the dispatcher our computer — it will filter events by eventType().
-  reg.dispatcher->addComputer(std::make_unique<SyntheticEventComputer>());
+  // Register the synthetic.tick computer factory. Each Dispatcher's onTick
+  // lazily instantiates one fresh SyntheticEventComputer per type.
+  reg.computers->registerFactory("synthetic.tick", [] {
+    return std::make_unique<SyntheticEventComputer>();
+  });
 
-  // Fire an event every tickMs. Tick loop re-arms itself until maxTicks is
-  // reached (0 = unbounded).
+  // Allocate the timer here; arming happens in start(), cancel in stop().
   _timer = std::make_unique<boost::asio::steady_timer>(*reg.io);
-  auto* timer = _timer.get();
-  auto streamKey = _opts.streamKey;
-  auto period    = std::chrono::milliseconds(std::max(1, _opts.tickMs));
-  int  maxTicks  = _opts.maxTicks;
-  auto counter   = std::make_shared<std::uint64_t>(0);
-  auto dispatcher = reg.dispatcher;
+  _dispatcher = reg.dispatcher;
+}
 
-  std::function<void(const boost::system::error_code&)> onExpiry;
+void SyntheticConnector::start() {
+  if (!_timer || !_dispatcher) return;
+
+  auto* timer        = _timer.get();
+  auto  streamKey    = _opts.streamKey;
+  auto  period       = std::chrono::milliseconds(std::max(1, _opts.tickMs));
+  int   maxTicks     = _opts.maxTicks;
+  auto  counter      = std::make_shared<std::uint64_t>(0);
+  auto* dispatcher   = _dispatcher;
+
   auto selfRef = std::make_shared<std::function<void(const boost::system::error_code&)>>();
-  onExpiry = [timer, streamKey, period, maxTicks, counter, dispatcher, selfRef]
+  *selfRef = [timer, streamKey, period, maxTicks, counter, dispatcher, selfRef]
              (const boost::system::error_code& ec) {
     if (ec) return;
     if (maxTicks > 0 && *counter >= static_cast<std::uint64_t>(maxTicks)) return;
@@ -84,17 +83,14 @@ void SyntheticConnector::registerWith(engine::EngineRegistries& reg) {
     timer->expires_after(period);
     timer->async_wait(*selfRef);
   };
-  *selfRef = std::move(onExpiry);
 
   timer->expires_after(period);
   timer->async_wait(*selfRef);
+}
 
-  if (reg.shutdown) {
-    auto* cancelable = _timer.get();
-    reg.shutdown->registerStep("synthetic-timer-cancel", 58, [cancelable] {
-      try { cancelable->cancel(); } catch (...) {}
-    });
-  }
+void SyntheticConnector::stop() noexcept {
+  if (!_timer) return;
+  try { _timer->cancel(); } catch (...) {}
 }
 
 } // namespace gma::synthetic

--- a/docs/CONNECTOR_REFACTOR.md
+++ b/docs/CONNECTOR_REFACTOR.md
@@ -111,15 +111,31 @@ gma_server                        composition root
 
 ### Composition root
 
+The composition root drives every connector through the same lifecycle:
+construct → `registerWith` → `start` → … → `stop` (in reverse-registration
+order via a single `connectors-stop` ShutdownCoordinator step at priority 30).
+Connectors do NOT register their own ShutdownCoordinator steps.
+
 ```cpp
 int main(int argc, char* argv[]) {
-  gma::engine::Engine engine = gma::engine::Engine::fromArgs(argc, argv);
+  // ... engine bootstrap (config, threadpool, store, dispatcher, ioc) ...
+  gma::engine::EngineRegistries regs{ /* 14 fields, see EngineRegistries.hpp */ };
 
-  // ─── one registration line per connector ───
-  gma::market::MarketConnector::registerWith(engine.registries());
-  // (future) gma::crypto::CoinbaseConnector::registerWith(engine.registries());
+  std::vector<gma::engine::IConnector*> connectors;
+  gma::market::MarketConnector marketConnector;
+  marketConnector.registerWith(regs);
+  connectors.push_back(&marketConnector);
+  // (future) gma::crypto::CoinbaseConnector{}.registerWith(regs);
 
-  engine.boot();
+  for (auto* c : connectors) c->start();
+  shutdown.registerStep("connectors-stop", 30, [&connectors] {
+    for (auto it = connectors.rbegin(); it != connectors.rend(); ++it) {
+      (*it)->stop();
+    }
+  });
+
+  ioc.run();           // event loop
+  shutdown.stop();     // drains every priority, including connectors-stop
   return 0;
 }
 ```

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -88,7 +88,7 @@ int main(int argc, char* argv[]) {
   if (argc > 1) wsPort   = parsePort(argv[1], wsPort);
   if (argc > 3) feedPort = parsePort(argv[3], feedPort);
 
-  // Make CLI overrides authoritative — MarketConnector reads cfg.feedPort.
+  // CLI args win over the config file — connectors read cfg.{wsPort,feedPort}.
   cfg.wsPort   = wsPort;
   cfg.feedPort = feedPort;
 
@@ -99,12 +99,10 @@ int main(int argc, char* argv[]) {
     {{"wsPort", std::to_string(wsPort)}, {"feedPort", std::to_string(feedPort)}}
   );
 
-  // 3) Engine bootstrap: register generic worker functions and node types, and
-  //    install the market-side default-computer-factory hook BEFORE the
-  //    dispatcher is constructed so it picks up a fresh MarketTickComputer.
+  // 3) Engine bootstrap: register generic worker functions and node types.
+  //    Connectors register their own event computers in registerWith().
   gma::registerBuiltinFunctions();
   gma::registerBuiltinNodeTypes();
-  gma::market::MarketConnector::installDefaults();
 
   // 4) Thread pool (global)
   unsigned poolSize = cfg.threadPoolSize > 0

--- a/tests/connectors/SyntheticConnectorTest.cpp
+++ b/tests/connectors/SyntheticConnectorTest.cpp
@@ -5,11 +5,14 @@
 #include "gma/AtomicStore.hpp"
 #include "gma/Dispatcher.hpp"
 #include "gma/Event.hpp"
-#include "gma/engine/EngineRegistries.hpp"
+#include "gma/FunctionMap.hpp"
+#include "gma/atomic/AtomicProviderRegistry.hpp"
+#include "gma/engine/Registries.hpp"
 #include "gma/rt/ThreadPool.hpp"
 #include "gma/runtime/ShutdownCoordinator.hpp"
 #include "gma/synthetic/SyntheticConnector.hpp"
 #include "gma/util/Config.hpp"
+#include "gma/util/Logger.hpp"
 
 #include <boost/asio/io_context.hpp>
 #include <boost/asio/post.hpp>
@@ -87,18 +90,70 @@ TEST(SyntheticConnectorTest, DispatcherRoutesByEventType) {
   EXPECT_FALSE(store.get("SYN", "lastPrice").has_value());
 }
 
-TEST(SyntheticConnectorTest, RegisterWithDrivesIoContext) {
-  // End-to-end: register the connector with a real EngineRegistries, run the
-  // io_context briefly, and verify the timer fired and the computer ran.
+namespace {
+
+// Build a fully-populated EngineRegistries pointing at the supplied per-test
+// engine objects. Mirrors what the composition root does in main().
+engine::EngineRegistries buildRegs(util::Config& cfg,
+                                   rt::ThreadPool& pool,
+                                   AtomicStore& store,
+                                   Dispatcher& dispatcher,
+                                   rt::ShutdownCoordinator& shutdown,
+                                   boost::asio::io_context& ioc) {
+  return engine::EngineRegistries{
+    &cfg, &pool, &store, &dispatcher, &shutdown, &ioc,
+    &engine::EventTypeRegistry::singleton(),
+    &engine::EventComputerRegistry::singleton(),
+    &engine::NodeTypeRegistry::singleton(),
+    &engine::IngressRegistry::singleton(),
+    &engine::ConfigNamespaceRegistry::singleton(),
+    &AtomicProviderRegistry::singleton(),
+    &FunctionMap::instance(),
+    &util::logger(),
+  };
+}
+
+} // namespace
+
+TEST(SyntheticConnectorTest, RegisterWithDoesNotFireTimer) {
+  // Lifecycle invariant: registerWith must allocate but not arm the timer.
+  // Running the io_context after registerWith alone should produce zero
+  // synthetic events, since start() has not been called.
   AtomicStore store;
   rt::ThreadPool pool(1);
   Dispatcher dispatcher(&pool, &store);
   boost::asio::io_context ioc;
-
   util::Config cfg;
   rt::ShutdownCoordinator shutdown;
 
-  engine::EngineRegistries regs{ &cfg, &pool, &store, &dispatcher, &shutdown, &ioc };
+  auto regs = buildRegs(cfg, pool, store, dispatcher, shutdown, ioc);
+
+  synthetic::SyntheticConnector::Options opts;
+  opts.streamKey = "SYN_NOSTART";
+  opts.tickMs    = 1;     // would fire fast if armed.
+  opts.maxTicks  = 5;
+  synthetic::SyntheticConnector connector(opts);
+  connector.registerWith(regs);
+
+  ioc.run_for(std::chrono::milliseconds(50));
+  pool.shutdown();
+
+  EXPECT_FALSE(store.get("SYN_NOSTART", "synthetic.sin").has_value())
+      << "registerWith leaked timer arming — start() should be the only path "
+         "that schedules events";
+}
+
+TEST(SyntheticConnectorTest, StartArmsTimerStopCancels) {
+  // End-to-end lifecycle: registerWith → start fires the timer; stop cancels
+  // any further callbacks. Verifies the post-phase-4 control flow.
+  AtomicStore store;
+  rt::ThreadPool pool(1);
+  Dispatcher dispatcher(&pool, &store);
+  boost::asio::io_context ioc;
+  util::Config cfg;
+  rt::ShutdownCoordinator shutdown;
+
+  auto regs = buildRegs(cfg, pool, store, dispatcher, shutdown, ioc);
 
   synthetic::SyntheticConnector::Options opts;
   opts.streamKey = "SYN_E2E";
@@ -106,12 +161,12 @@ TEST(SyntheticConnectorTest, RegisterWithDrivesIoContext) {
   opts.maxTicks  = 3;
   synthetic::SyntheticConnector connector(opts);
   connector.registerWith(regs);
+  connector.start();
 
-  // Drive the timer until all three ticks fire.
   ioc.run_for(std::chrono::milliseconds(200));
-  shutdown.stop();
+  connector.stop();
   pool.shutdown();
 
-  auto sin0 = store.get("SYN_E2E", "synthetic.sin");
-  ASSERT_TRUE(sin0.has_value()) << "computer never ran — timer didn't dispatch";
+  EXPECT_TRUE(store.get("SYN_E2E", "synthetic.sin").has_value())
+      << "computer never ran — start() didn't arm the timer";
 }

--- a/tests/engine/ConnectorLifecycleTest.cpp
+++ b/tests/engine/ConnectorLifecycleTest.cpp
@@ -1,0 +1,128 @@
+// Pins the IConnector lifecycle contract documented on IConnector.hpp:
+//   1. registerWith() exactly once
+//   2. start() exactly once, after registerWith
+//   3. stop() noexcept, after start; safe to call multiple times
+//   4. multiple connectors stopped in reverse-registration order
+//   5. double-start is a programmer error → throws std::logic_error
+//
+// Uses a hand-rolled MockConnector that records call ordering rather than
+// touching any of the production connectors (their behavior is covered by
+// MarketConnector / SyntheticConnector tests respectively).
+
+#include "gma/engine/IConnector.hpp"
+#include "gma/engine/Registries.hpp"
+
+#include <gtest/gtest.h>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace {
+
+// Mock that appends a tagged string to a shared trace whenever a lifecycle
+// method is called. start() can optionally throw on the second call to
+// exercise case 5.
+class MockConnector final : public gma::engine::IConnector {
+public:
+  MockConnector(std::string tag, std::vector<std::string>* trace)
+    : _tag(std::move(tag)), _trace(trace) {}
+
+  std::string_view name() const override { return _tag; }
+
+  void registerWith(gma::engine::EngineRegistries&) override {
+    ++_registerCalls;
+    _trace->push_back(_tag + ":registerWith");
+  }
+
+  void start() override {
+    if (_started) {
+      throw std::logic_error(_tag + ": double-start");
+    }
+    _started = true;
+    _trace->push_back(_tag + ":start");
+  }
+
+  void stop() noexcept override {
+    // Idempotent: multiple stop() calls are safe and only the first records.
+    if (!_started) return;
+    _started = false;
+    _trace->push_back(_tag + ":stop");
+  }
+
+  int registerCalls() const { return _registerCalls; }
+
+private:
+  std::string _tag;
+  std::vector<std::string>* _trace;
+  bool _started{false};
+  int  _registerCalls{0};
+};
+
+} // namespace
+
+TEST(ConnectorLifecycleTest, RegisterWithCalledExactlyOnce) {
+  std::vector<std::string> trace;
+  MockConnector m("A", &trace);
+  gma::engine::EngineRegistries regs{};
+  m.registerWith(regs);
+  EXPECT_EQ(m.registerCalls(), 1);
+  ASSERT_EQ(trace.size(), 1u);
+  EXPECT_EQ(trace[0], "A:registerWith");
+}
+
+TEST(ConnectorLifecycleTest, StartFollowsRegisterWith) {
+  std::vector<std::string> trace;
+  MockConnector m("A", &trace);
+  gma::engine::EngineRegistries regs{};
+  m.registerWith(regs);
+  m.start();
+  ASSERT_EQ(trace.size(), 2u);
+  EXPECT_EQ(trace[0], "A:registerWith");
+  EXPECT_EQ(trace[1], "A:start");
+}
+
+TEST(ConnectorLifecycleTest, StopOrderIsReverseOfRegistration) {
+  std::vector<std::string> trace;
+  MockConnector a("A", &trace);
+  MockConnector b("B", &trace);
+  gma::engine::EngineRegistries regs{};
+
+  std::vector<gma::engine::IConnector*> connectors{&a, &b};
+  for (auto* c : connectors) c->registerWith(regs);
+  for (auto* c : connectors) c->start();
+  // Reverse-order stop, mirroring main.cpp's "connectors-stop" step.
+  for (auto it = connectors.rbegin(); it != connectors.rend(); ++it) (*it)->stop();
+
+  ASSERT_EQ(trace.size(), 6u);
+  EXPECT_EQ(trace[0], "A:registerWith");
+  EXPECT_EQ(trace[1], "B:registerWith");
+  EXPECT_EQ(trace[2], "A:start");
+  EXPECT_EQ(trace[3], "B:start");
+  // The critical assertion: B stops before A.
+  EXPECT_EQ(trace[4], "B:stop");
+  EXPECT_EQ(trace[5], "A:stop");
+}
+
+TEST(ConnectorLifecycleTest, StopIsIdempotent) {
+  std::vector<std::string> trace;
+  MockConnector m("A", &trace);
+  gma::engine::EngineRegistries regs{};
+  m.registerWith(regs);
+  m.start();
+  m.stop();
+  m.stop();   // second call must not throw and must not record.
+  m.stop();   // third call ditto.
+
+  ASSERT_EQ(trace.size(), 3u);
+  EXPECT_EQ(trace[2], "A:stop");
+}
+
+TEST(ConnectorLifecycleTest, DoubleStartThrowsLogicError) {
+  std::vector<std::string> trace;
+  MockConnector m("A", &trace);
+  gma::engine::EngineRegistries regs{};
+  m.registerWith(regs);
+  m.start();
+  EXPECT_THROW(m.start(), std::logic_error);
+}

--- a/tests/test_bootstrap.cpp
+++ b/tests/test_bootstrap.cpp
@@ -1,20 +1,76 @@
 // Runs once per test-binary boot. Registers engine builtins (worker functions
-// and node types) and installs the market connector's default computer factory
-// so every Dispatcher constructed inside any test picks up its own
-// MarketTickComputer.
+// and node types), constructs a process-static MarketConnector, and calls its
+// registerWith() — NOT start(). Tests don't need live sockets, so the feed
+// server / WS clients are constructed but never started. The "tick" event
+// computer factory is registered with EventComputerRegistry as a side effect
+// of registerWith, so every Dispatcher built in any test picks up its own
+// fresh MarketTickComputer the first time it sees a tick.
+
+#include "gma/AtomicStore.hpp"
+#include "gma/Dispatcher.hpp"
+#include "gma/FunctionMap.hpp"
 #include "gma/FunctionRegistry.hpp"
 #include "gma/NodeRegistry.hpp"
+#include "gma/atomic/AtomicProviderRegistry.hpp"
+#include "gma/engine/Registries.hpp"
 #include "gma/market/MarketConnector.hpp"
+#include "gma/rt/ThreadPool.hpp"
+#include "gma/runtime/ShutdownCoordinator.hpp"
+#include "gma/util/Config.hpp"
+#include "gma/util/Logger.hpp"
+
+#include <boost/asio/io_context.hpp>
 #include <gtest/gtest.h>
 
+#include <memory>
+
 namespace {
+
+// Process-static singletons so the connector's captured pointers stay valid
+// for the entire test-binary lifetime.
+struct TestFixtureGlobals {
+  gma::util::Config             cfg;
+  std::unique_ptr<gma::rt::ThreadPool>   pool;
+  std::unique_ptr<gma::AtomicStore>      store;
+  std::unique_ptr<gma::Dispatcher>       dispatcher;
+  std::unique_ptr<gma::rt::ShutdownCoordinator> shutdown;
+  std::unique_ptr<boost::asio::io_context> ioc;
+  std::unique_ptr<gma::market::MarketConnector> market;
+};
+
+TestFixtureGlobals& globals() {
+  static TestFixtureGlobals g;
+  return g;
+}
 
 class BuiltinsEnvironment : public ::testing::Environment {
 public:
   void SetUp() override {
     gma::registerBuiltinFunctions();
     gma::registerBuiltinNodeTypes();
-    gma::market::MarketConnector::installDefaults();
+
+    auto& g = globals();
+    g.pool       = std::make_unique<gma::rt::ThreadPool>(1);
+    g.store      = std::make_unique<gma::AtomicStore>();
+    g.dispatcher = std::make_unique<gma::Dispatcher>(g.pool.get(), g.store.get(), g.cfg);
+    g.shutdown   = std::make_unique<gma::rt::ShutdownCoordinator>();
+    g.ioc        = std::make_unique<boost::asio::io_context>();
+    g.market     = std::make_unique<gma::market::MarketConnector>();
+
+    gma::engine::EngineRegistries regs{
+      &g.cfg, g.pool.get(), g.store.get(), g.dispatcher.get(),
+      g.shutdown.get(), g.ioc.get(),
+      &gma::engine::EventTypeRegistry::singleton(),
+      &gma::engine::EventComputerRegistry::singleton(),
+      &gma::engine::NodeTypeRegistry::singleton(),
+      &gma::engine::IngressRegistry::singleton(),
+      &gma::engine::ConfigNamespaceRegistry::singleton(),
+      &gma::AtomicProviderRegistry::singleton(),
+      &gma::FunctionMap::instance(),
+      &gma::util::logger(),
+    };
+
+    g.market->registerWith(regs);   // NOTE: no start() — tests do not run sockets.
   }
 };
 


### PR DESCRIPTION
Stacked on top of #4 (phase 3). Final phase of the **connector-lifecycle** project.

## Summary
**MarketConnector**
- `registerWith` only constructs + registers; no live sockets or timers. All 5 `reg.shutdown->registerStep` calls removed.
- `start()` runs the `FeedServer` and starts every WS feed client.
- `stop() noexcept` reverse-order teardown — feed clients (was priority 56) → feed server (was 55) → `AtomicProviderRegistry::clear` (was 50). Idempotent.
- `installDefaults()` deleted; header drops the declaration.

**FeedServer**
- Constructor is now side-effect-free: `open`/`bind`/`listen` moved to `run()`. Lets `MarketConnector::registerWith` construct the server without holding port 9001 — the spec's \"construct, don't run\" intent.

**SyntheticConnector**
- `registerWith` allocates the timer + registers `synthetic.tick` factory via `reg.computers`.
- `start()` arms the timer.
- `stop() noexcept` cancels.

**main.cpp**
- Drop `MarketConnector::installDefaults()` call + stale comments.

**test_bootstrap.cpp**
- Replace `installDefaults()` with construction + `registerWith` (NOT `start` — fixture must not start sockets).

**Tests**
- New `ConnectorLifecycleTest` (5 cases) with hand-rolled `MockConnector`: registerWith called once; start follows registerWith; stop in reverse-registration order across two connectors; stop idempotent; double-start throws `std::logic_error`.
- `SyntheticConnectorTest`: split into `RegisterWithDoesNotFireTimer` + `StartArmsTimerStopCancels`.

**Docs**
- `CLAUDE.md` Code Conventions: lifecycle bullet.
- `docs/CONNECTOR_REFACTOR.md § Composition root`: real construct → registerWith → start → connectors-stop pattern.

## Linear
Closes ENC-62..69. Satisfies AC1 (ENC-70), AC4 (ENC-73), AC5 (ENC-74), AC6 (ENC-75), AC7 (ENC-76). **Project complete.**

## Test plan
- [x] `ctest --output-on-failure` — 375/375 pass (+5 lifecycle, +1 synthetic re-split)
- [x] `bench_dispatcher` — 568.865k items/s vs baseline 481.369k
- [x] `gma_engine` builds without any `connectors/` headers (engine isolation, AC7)
- [x] `git grep registerStep connectors/` returns no hits (AC1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)