### PR TITLE
[connector-lifecycle phases 2-4] bring stacked changes onto master

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,7 @@ See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for the full picture including 
 - Runtime config: INI-style key=value files (see `src/util/gma.conf`)
 - Prefer lock-free / fine-grained locking (shared_mutex, SPSCQueue)
 - Test files named `<Component>Test.cpp` under `tests/<category>/`; the gtest binary is a single `gma_tests` executable
+- Connectors implement the strict `IConnector` lifecycle: `registerWith()` allocates and registers (no live sockets/timers), `start()` brings sources online, `stop()` noexcept tears down in reverse order. The composition root drives all three; never wire your own `ShutdownCoordinator` step from inside a connector.
 
 ## Configuration
 

--- a/connectors/market/include/gma/market/MarketConnector.hpp
+++ b/connectors/market/include/gma/market/MarketConnector.hpp
@@ -16,34 +16,34 @@ class FeedServer;
 namespace gma::market {
 
 // The market connector owns everything market-specific: order book engine,
-// TA tick computer (via DefaultComputerFactory hook), "ob.*" atomic provider
-// namespace, TCP FeedServer, and external WsFeedClients driven by ItchAdapter.
+// TA tick computer (registered with EventComputerRegistry), "ob.*" atomic
+// provider namespace, TCP FeedServer, and external WsFeedClients driven by
+// ItchAdapter.
 //
-// Usage in main():
-//   MarketConnector::installDefaults();          // install TA computer hook
-//   // ... construct engine pieces (pool/store/dispatcher/ioc) ...
+// Lifecycle (driven by the composition root):
 //   MarketConnector connector;
-//   EngineRegistries regs{ &cfg, pool, store, dispatcher, &shutdown, &ioc };
-//   connector.registerWith(regs);                // everything else
+//   connector.registerWith(regs);   // construct + register; nothing running
+//   connector.start();              // run the feed server + WS clients
+//   ...
+//   connector.stop();               // reverse-order teardown (idempotent)
 class MarketConnector final : public engine::IConnector {
 public:
-  // Install the Dispatcher DefaultComputerFactory hook so every
-  // dispatcher constructed after this call gets its own MarketTickComputer.
-  // Safe to call multiple times (idempotent replace).
-  static void installDefaults();
-
   MarketConnector();
   ~MarketConnector() override;
 
   std::string_view name() const override { return "market"; }
 
-  // Full market boot: construct OrderBookManager, wire its provider into the
-  // AtomicProviderRegistry under "ob.*", start the TCP FeedServer on
-  // cfg.feedPort, spin up configured WsFeedClients, and register all
-  // shutdown steps on reg.shutdown. Returns with the servers running inside
-  // reg.io (which the caller drives via io.run()).
+  // Construct OrderBookManager, wire its provider into AtomicProviderRegistry
+  // under "ob.*", construct (do NOT run) the TCP FeedServer on cfg.feedPort,
+  // construct (do NOT start) configured WsFeedClients, and register the
+  // "tick" event-computer factory.
   void registerWith(engine::EngineRegistries& reg) override;
+
+  // Run the feed server + WS feed clients. Failures on individual feed
+  // clients are logged and do not abort the rest.
   void start() override;
+
+  // Reverse-order teardown. Idempotent: a second call is a no-op.
   void stop() noexcept override;
 
 private:

--- a/connectors/market/include/gma/server/FeedServer.hpp
+++ b/connectors/market/include/gma/server/FeedServer.hpp
@@ -46,6 +46,7 @@ private:
   boost::asio::io_context& ioc_;
   tcp::acceptor            acceptor_;
   std::atomic<bool>        accepting_{false};
+  unsigned short           port_{0};
 
   Dispatcher*        dispatcher_; // not owned
   OrderBookManager*        obManager_{nullptr}; // not owned

--- a/connectors/market/src/MarketConnector.cpp
+++ b/connectors/market/src/MarketConnector.cpp
@@ -3,6 +3,7 @@
 #include <cstdlib>
 #include <limits>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <utility>
 
@@ -11,6 +12,7 @@
 #include "gma/MarketTA.hpp"
 #include "gma/atomic/AtomicProviderRegistry.hpp"
 #include "gma/book/OrderBookManager.hpp"
+#include "gma/engine/EventComputerRegistry.hpp"
 #include "gma/engine/IEventComputer.hpp"
 #include "gma/feed/IFeedAdapter.hpp"
 #include "gma/feed/ItchAdapter.hpp"
@@ -39,12 +41,24 @@ void MarketConnector::stop() noexcept {
 }
 
 void MarketConnector::installDefaults() {
-  Dispatcher::setDefaultComputerFactory(
-    [](const util::Config& cfg) {
-      std::vector<std::unique_ptr<engine::IEventComputer>> out;
-      out.push_back(std::make_unique<MarketTickComputer>(cfg));
-      return out;
-    });
+  // Register the market tick computer factory with the engine. Every
+  // Dispatcher built after this call will lazily pick up a fresh
+  // MarketTickComputer the first time it sees a "tick" event.
+  //
+  // EventComputerRegistry::registerFactory is additive, but main.cpp +
+  // registerWith() both invoke this — std::call_once preserves the
+  // "safe to call multiple times" idempotent-replace semantics.
+  //
+  // The factory receives each Dispatcher's own util::Config so per-Dispatcher
+  // tuning (sourceProfile, taHistoryMax, …) is honored. Phase 4 will move
+  // this registration into registerWith() where reg.cfg is also available.
+  static std::once_flag once;
+  std::call_once(once, [] {
+    engine::EventComputerRegistry::registerFactory("tick",
+      [](const util::Config& cfg) {
+        return std::make_unique<MarketTickComputer>(cfg);
+      });
+  });
 }
 
 void MarketConnector::registerWith(engine::EngineRegistries& reg) {

--- a/connectors/market/src/MarketConnector.cpp
+++ b/connectors/market/src/MarketConnector.cpp
@@ -3,8 +3,8 @@
 #include <cstdlib>
 #include <limits>
 #include <memory>
-#include <mutex>
 #include <optional>
+#include <stdexcept>
 #include <utility>
 
 #include "gma/AtomicStore.hpp"
@@ -19,7 +19,6 @@
 #include "gma/ob/FunctionalSnapshotSource.hpp"
 #include "gma/ob/ObMaterializer.hpp"
 #include "gma/ob/ObProvider.hpp"
-#include "gma/runtime/ShutdownCoordinator.hpp"
 #include "gma/server/FeedServer.hpp"
 #include "gma/util/Config.hpp"
 #include "gma/util/Logger.hpp"
@@ -30,49 +29,11 @@ namespace gma::market {
 MarketConnector::MarketConnector()  = default;
 MarketConnector::~MarketConnector() = default;
 
-void MarketConnector::start() {
-  // TODO: phase-4 — move feed run/client start/OB init from registerWith into
-  // start; mirror in stop.
-}
-
-void MarketConnector::stop() noexcept {
-  // TODO: phase-4 — reverse-order teardown of feed clients, feed server, and
-  // AtomicProviderRegistry.
-}
-
-void MarketConnector::installDefaults() {
-  // Register the market tick computer factory with the engine. Every
-  // Dispatcher built after this call will lazily pick up a fresh
-  // MarketTickComputer the first time it sees a "tick" event.
-  //
-  // EventComputerRegistry::registerFactory is additive, but main.cpp +
-  // registerWith() both invoke this — std::call_once preserves the
-  // "safe to call multiple times" idempotent-replace semantics.
-  //
-  // The factory receives each Dispatcher's own util::Config so per-Dispatcher
-  // tuning (sourceProfile, taHistoryMax, …) is honored. Phase 4 will move
-  // this registration into registerWith() where reg.cfg is also available.
-  static std::once_flag once;
-  std::call_once(once, [] {
-    engine::EventComputerRegistry::registerFactory("tick",
-      [](const util::Config& cfg) {
-        return std::make_unique<MarketTickComputer>(cfg);
-      });
-  });
-}
-
 void MarketConnector::registerWith(engine::EngineRegistries& reg) {
-  using util::logger;
-  using util::LogLevel;
-
-  if (!reg.cfg || !reg.shutdown || !reg.io || !reg.dispatcher) {
+  if (!reg.cfg || !reg.io || !reg.dispatcher || !reg.computers) {
     throw std::runtime_error("MarketConnector: incomplete EngineRegistries");
   }
   const util::Config& cfg = *reg.cfg;
-
-  // Ensure the computer factory hook is installed — safe no-op if the caller
-  // already did it, so consumers don't have to remember two steps.
-  installDefaults();
 
   // ---- Order book engine ----
   _obManager = std::make_shared<OrderBookManager>();
@@ -117,22 +78,20 @@ void MarketConnector::registerWith(engine::EngineRegistries& reg) {
       return obProvider->get(symbol, fullKey);
     });
 
-  reg.shutdown->registerStep("ob-provider-clear", 50, [] {
-    AtomicProviderRegistry::clear();
-  });
+  // Register the "tick" computer factory through the engine registry. Each
+  // Dispatcher's onTick lazily instantiates one MarketTickComputer per type
+  // using the dispatcher's own cfg, so per-Dispatcher tuning is honored.
+  reg.computers->registerFactory("tick",
+    [](const util::Config& dispatcherCfg) {
+      return std::make_unique<MarketTickComputer>(dispatcherCfg);
+    });
 
-  // ---- TCP FeedServer (market message schema) ----
+  // ---- TCP FeedServer (constructed, not started) ----
   const unsigned short feedPort = static_cast<unsigned short>(cfg.feedPort);
   _feedServer = std::make_unique<FeedServer>(*reg.io, reg.dispatcher,
                                              _obManager.get(), feedPort);
-  _feedServer->run();
 
-  FeedServer* feedPtr = _feedServer.get();
-  reg.shutdown->registerStep("feed-stop", 55, [feedPtr] {
-    try { feedPtr->stop(); } catch (...) {}
-  });
-
-  // ---- External WS feed clients ----
+  // ---- External WS feed clients (constructed, not started) ----
   auto effectiveFeeds = cfg.feeds;
   if (effectiveFeeds.empty()) {
     std::string feedUrl = cfg.feedUrl;
@@ -149,42 +108,62 @@ void MarketConnector::registerWith(engine::EngineRegistries& reg) {
     }
   }
 
-  for (std::size_t i = 0; i < effectiveFeeds.size(); ++i) {
-    const auto& fc = effectiveFeeds[i];
+  for (const auto& fc : effectiveFeeds) {
     if (fc.url.empty()) continue;
 
+    std::unique_ptr<feed::IFeedAdapter> adapter;
+    if (fc.adapter == "itch") {
+      adapter = std::make_unique<feed::ItchAdapter>();
+    } else {
+      // Default to ITCH; future: "generic", "coinbase", …
+      adapter = std::make_unique<feed::ItchAdapter>();
+    }
+
+    auto client = std::make_shared<ws::WsFeedClient>(
+        *reg.io, reg.dispatcher, _obManager.get(),
+        fc.url, std::move(adapter), fc.symbols);
+    _feedClients.push_back(std::move(client));
+  }
+}
+
+void MarketConnector::start() {
+  using util::logger;
+  using util::LogLevel;
+
+  if (_feedServer) {
+    _feedServer->run();
+  }
+
+  for (std::size_t i = 0; i < _feedClients.size(); ++i) {
+    auto& client = _feedClients[i];
+    if (!client) continue;
     try {
-      std::unique_ptr<feed::IFeedAdapter> adapter;
-      if (fc.adapter == "itch") {
-        adapter = std::make_unique<feed::ItchAdapter>();
-      } else {
-        // Default to ITCH; future: "generic", "coinbase", …
-        adapter = std::make_unique<feed::ItchAdapter>();
-      }
-
-      auto client = std::make_shared<ws::WsFeedClient>(
-          *reg.io, reg.dispatcher, _obManager.get(),
-          fc.url, std::move(adapter), fc.symbols);
       client->start();
-      _feedClients.push_back(client);
-
       logger().log(LogLevel::Info, "feed_client.started",
-                   {{"url", fc.url}, {"adapter", fc.adapter},
-                    {"index", std::to_string(i)}});
+                   {{"index", std::to_string(i)}});
     } catch (const std::exception& ex) {
       logger().log(LogLevel::Error, "feed_client.start_failed",
-                   {{"err", ex.what()}, {"url", fc.url},
-                    {"index", std::to_string(i)}});
+                   {{"err", ex.what()}, {"index", std::to_string(i)}});
     }
   }
-  for (auto& fc : _feedClients) {
-    auto weak = std::weak_ptr<ws::WsFeedClient>(fc);
-    reg.shutdown->registerStep("feed-ws-stop", 56, [weak] {
-      if (auto s = weak.lock()) {
-        try { s->stop(); } catch (...) {}
-      }
-    });
+}
+
+void MarketConnector::stop() noexcept {
+  // Reverse of start / registerWith. Old per-step priorities preserved as
+  // comments so reviewers can map the old ShutdownCoordinator order to here.
+  for (auto& fc : _feedClients) {           // was priority 56 (feed-ws-stop)
+    if (!fc) continue;
+    try { fc->stop(); } catch (...) {}
   }
+  _feedClients.clear();
+
+  if (_feedServer) {                        // was priority 55 (feed-stop)
+    try { _feedServer->stop(); } catch (...) {}
+    _feedServer.reset();
+  }
+
+  try { AtomicProviderRegistry::clear(); }  // was priority 50 (ob-provider-clear)
+  catch (...) {}
 }
 
 } // namespace gma::market

--- a/connectors/market/src/server/FeedServer.cpp
+++ b/connectors/market/src/server/FeedServer.cpp
@@ -345,10 +345,20 @@ FeedServer::FeedServer(boost::asio::io_context& ioc,
   : ioc_(ioc),
     acceptor_(ioc),
     dispatcher_(dispatcher),
-    obManager_(obManager)
+    obManager_(obManager),
+    port_(port)
 {
+  // Constructor is intentionally side-effect-free — no bind, no listen.
+  // run() opens the socket so callers can construct ahead of start (per
+  // the IConnector lifecycle: registerWith allocates, start brings up).
+}
+
+void FeedServer::run() {
+  bool expected = false;
+  if (!accepting_.compare_exchange_strong(expected, true)) return;
+
   boost::system::error_code ec;
-  tcp::endpoint ep{tcp::v4(), port};
+  tcp::endpoint ep{tcp::v4(), port_};
 
   acceptor_.open(ep.protocol(), ec);
   if (ec) throw boost::system::system_error(ec);
@@ -361,11 +371,7 @@ FeedServer::FeedServer(boost::asio::io_context& ioc,
 
   acceptor_.listen(boost::asio::socket_base::max_listen_connections, ec);
   if (ec) throw boost::system::system_error(ec);
-}
 
-void FeedServer::run() {
-  bool expected = false;
-  if (!accepting_.compare_exchange_strong(expected, true)) return;
   doAccept();
 }
 

--- a/connectors/synthetic/include/gma/synthetic/SyntheticConnector.hpp
+++ b/connectors/synthetic/include/gma/synthetic/SyntheticConnector.hpp
@@ -10,6 +10,10 @@
 #include "gma/engine/IConnector.hpp"
 #include "gma/engine/IEventComputer.hpp"
 
+namespace gma {
+class Dispatcher;
+}
+
 namespace gma::synthetic {
 
 // Demo connector that proves the engine/connector boundary: it lives entirely
@@ -37,6 +41,7 @@ public:
 private:
   Options                               _opts;
   std::unique_ptr<boost::asio::steady_timer> _timer;
+  Dispatcher*                           _dispatcher { nullptr };
   std::uint64_t                         _counter { 0 };
 };
 

--- a/connectors/synthetic/src/SyntheticConnector.cpp
+++ b/connectors/synthetic/src/SyntheticConnector.cpp
@@ -4,6 +4,7 @@
 #include <cmath>
 #include <functional>
 #include <memory>
+#include <stdexcept>
 
 #include <boost/asio/io_context.hpp>
 #include <boost/asio/steady_timer.hpp>
@@ -12,7 +13,7 @@
 #include "gma/AtomicStore.hpp"
 #include "gma/Dispatcher.hpp"
 #include "gma/Event.hpp"
-#include "gma/runtime/ShutdownCoordinator.hpp"
+#include "gma/engine/EventComputerRegistry.hpp"
 
 namespace gma::synthetic {
 
@@ -34,36 +35,34 @@ SyntheticConnector::SyntheticConnector() = default;
 SyntheticConnector::SyntheticConnector(Options opts) : _opts(std::move(opts)) {}
 SyntheticConnector::~SyntheticConnector() = default;
 
-void SyntheticConnector::start() {
-  // TODO: phase-4 — move timer arm (expires_after + async_wait) here.
-}
-
-void SyntheticConnector::stop() noexcept {
-  // TODO: phase-4 — cancel the timer here (currently done via the
-  // synthetic-timer-cancel ShutdownCoordinator step).
-}
-
 void SyntheticConnector::registerWith(engine::EngineRegistries& reg) {
-  if (!reg.dispatcher || !reg.io) {
+  if (!reg.dispatcher || !reg.io || !reg.computers) {
     throw std::runtime_error("SyntheticConnector: incomplete EngineRegistries");
   }
 
-  // Hand the dispatcher our computer — it will filter events by eventType().
-  reg.dispatcher->addComputer(std::make_unique<SyntheticEventComputer>());
+  // Register the synthetic.tick computer factory. Each Dispatcher's onTick
+  // lazily instantiates one fresh SyntheticEventComputer per type.
+  reg.computers->registerFactory("synthetic.tick", [] {
+    return std::make_unique<SyntheticEventComputer>();
+  });
 
-  // Fire an event every tickMs. Tick loop re-arms itself until maxTicks is
-  // reached (0 = unbounded).
+  // Allocate the timer here; arming happens in start(), cancel in stop().
   _timer = std::make_unique<boost::asio::steady_timer>(*reg.io);
-  auto* timer = _timer.get();
-  auto streamKey = _opts.streamKey;
-  auto period    = std::chrono::milliseconds(std::max(1, _opts.tickMs));
-  int  maxTicks  = _opts.maxTicks;
-  auto counter   = std::make_shared<std::uint64_t>(0);
-  auto dispatcher = reg.dispatcher;
+  _dispatcher = reg.dispatcher;
+}
 
-  std::function<void(const boost::system::error_code&)> onExpiry;
+void SyntheticConnector::start() {
+  if (!_timer || !_dispatcher) return;
+
+  auto* timer        = _timer.get();
+  auto  streamKey    = _opts.streamKey;
+  auto  period       = std::chrono::milliseconds(std::max(1, _opts.tickMs));
+  int   maxTicks     = _opts.maxTicks;
+  auto  counter      = std::make_shared<std::uint64_t>(0);
+  auto* dispatcher   = _dispatcher;
+
   auto selfRef = std::make_shared<std::function<void(const boost::system::error_code&)>>();
-  onExpiry = [timer, streamKey, period, maxTicks, counter, dispatcher, selfRef]
+  *selfRef = [timer, streamKey, period, maxTicks, counter, dispatcher, selfRef]
              (const boost::system::error_code& ec) {
     if (ec) return;
     if (maxTicks > 0 && *counter >= static_cast<std::uint64_t>(maxTicks)) return;
@@ -84,17 +83,14 @@ void SyntheticConnector::registerWith(engine::EngineRegistries& reg) {
     timer->expires_after(period);
     timer->async_wait(*selfRef);
   };
-  *selfRef = std::move(onExpiry);
 
   timer->expires_after(period);
   timer->async_wait(*selfRef);
+}
 
-  if (reg.shutdown) {
-    auto* cancelable = _timer.get();
-    reg.shutdown->registerStep("synthetic-timer-cancel", 58, [cancelable] {
-      try { cancelable->cancel(); } catch (...) {}
-    });
-  }
+void SyntheticConnector::stop() noexcept {
+  if (!_timer) return;
+  try { _timer->cancel(); } catch (...) {}
 }
 
 } // namespace gma::synthetic

--- a/docs/CONNECTOR_REFACTOR.md
+++ b/docs/CONNECTOR_REFACTOR.md
@@ -111,15 +111,31 @@ gma_server                        composition root
 
 ### Composition root
 
+The composition root drives every connector through the same lifecycle:
+construct → `registerWith` → `start` → … → `stop` (in reverse-registration
+order via a single `connectors-stop` ShutdownCoordinator step at priority 30).
+Connectors do NOT register their own ShutdownCoordinator steps.
+
 ```cpp
 int main(int argc, char* argv[]) {
-  gma::engine::Engine engine = gma::engine::Engine::fromArgs(argc, argv);
+  // ... engine bootstrap (config, threadpool, store, dispatcher, ioc) ...
+  gma::engine::EngineRegistries regs{ /* 14 fields, see EngineRegistries.hpp */ };
 
-  // ─── one registration line per connector ───
-  gma::market::MarketConnector::registerWith(engine.registries());
-  // (future) gma::crypto::CoinbaseConnector::registerWith(engine.registries());
+  std::vector<gma::engine::IConnector*> connectors;
+  gma::market::MarketConnector marketConnector;
+  marketConnector.registerWith(regs);
+  connectors.push_back(&marketConnector);
+  // (future) gma::crypto::CoinbaseConnector{}.registerWith(regs);
 
-  engine.boot();
+  for (auto* c : connectors) c->start();
+  shutdown.registerStep("connectors-stop", 30, [&connectors] {
+    for (auto it = connectors.rbegin(); it != connectors.rend(); ++it) {
+      (*it)->stop();
+    }
+  });
+
+  ioc.run();           // event loop
+  shutdown.stop();     // drains every priority, including connectors-stop
   return 0;
 }
 ```

--- a/include/gma/Dispatcher.hpp
+++ b/include/gma/Dispatcher.hpp
@@ -4,6 +4,7 @@
 #include <functional>
 #include <map>
 #include <memory>
+#include <mutex>
 #include <shared_mutex>
 #include <string>
 #include <unordered_map>
@@ -13,6 +14,7 @@
 #include "gma/FunctionMap.hpp"
 #include "gma/Event.hpp"
 #include "gma/StreamValue.hpp"
+#include "gma/engine/EventComputerRegistry.hpp"
 #include "gma/engine/IEventComputer.hpp"
 #include "gma/nodes/INode.hpp"
 #include "gma/rt/ThreadPool.hpp"
@@ -26,30 +28,20 @@ namespace gma {
  * can be recomputed on each update.
  *
  * Domain-specific computations (market TA, order-book derivations, …) live in
- * IEventComputer implementations owned by the dispatcher. They are invoked on
- * every onTick BEFORE the raw-field notify loop runs. Computers may call
- * notifyListeners() to deliver their computed values to subscribers.
- *
- * Renamed to engine::Dispatcher in a later step — this class will become the
- * generic routing layer. Until then, the market tick computer is wired in by
- * the constructor for backward compatibility with existing call sites.
+ * IEventComputer implementations sourced from EventComputerRegistry. The
+ * dispatcher caches per-type computer instances lazily on first event of
+ * each type, so late-registered factories are picked up automatically.
+ * Computers may call notifyListeners() to deliver values to subscribers.
  */
 class Dispatcher {
 public:
   Dispatcher(gma::rt::ThreadPool* threadPool, AtomicStore* store,
                    const util::Config& cfg = util::Config{});
 
-  // Factory hook installed by the market side at boot. Every new dispatcher
-  // calls this (if installed) to populate its computers list — lets the engine
-  // header avoid any market include while preserving existing construction
-  // call sites. Removed in Step 8 when IConnector formalization lands.
-  using DefaultComputerFactory =
-      std::function<std::vector<std::unique_ptr<engine::IEventComputer>>(
-          const util::Config&)>;
-  static void setDefaultComputerFactory(DefaultComputerFactory f);
-
   // Append an event computer after construction. Primarily used by tests and
-  // code paths that want TA without depending on the default-factory hook.
+  // code paths that want a computer without going through
+  // EventComputerRegistry. Connectors should prefer the registry path so the
+  // dispatcher's per-type cache picks them up automatically.
   void addComputer(std::unique_ptr<engine::IEventComputer> computer);
 
   void registerListener(const std::string& symbol,
@@ -89,9 +81,20 @@ private:
       std::map<std::string, std::vector<std::shared_ptr<INode>>>
   > _listeners;
 
-  // Domain-specific computers (e.g. MarketTickComputer for TA). Constructed in
-  // the ctor; invoked on every onTick in registration order.
+  // Computers added explicitly via addComputer(). Filtered by eventType() on
+  // every onTick. Kept separate from the registry-driven cache so test code
+  // can inject computers without touching the global EventComputerRegistry.
   std::vector<std::unique_ptr<engine::IEventComputer>> _computers;
+
+  // Per-type cache of computers built from EventComputerRegistry. Populated
+  // lazily on first event of a given type — every `onTick` for an unseen
+  // type calls EventComputerRegistry::createAll(type) and caches the result
+  // for the lifetime of this Dispatcher. Late-registered factories are
+  // therefore picked up on the first event of their type.
+  std::unordered_map<std::string,
+                     std::vector<std::unique_ptr<engine::IEventComputer>>>
+                                          _computersByType;
+  mutable std::mutex                      _computerCacheMx;
 
   mutable std::shared_mutex _histMutex;
   mutable std::shared_mutex _listenerMutex;

--- a/include/gma/atomic/AtomicProviderRegistry.hpp
+++ b/include/gma/atomic/AtomicProviderRegistry.hpp
@@ -12,6 +12,13 @@ class AtomicProviderRegistry {
 public:
   using ProviderFn = std::function<double(const std::string& symbol, const std::string& fullKey)>;
 
+  // Tag instance — registry methods are static, so this is purely a handle for
+  // EngineRegistries to expose alongside the per-instance singletons.
+  static AtomicProviderRegistry& singleton() {
+    static AtomicProviderRegistry s;
+    return s;
+  }
+
   // Register (or replace) a provider function for a namespace, e.g., "ema", "vwap"
   static void registerNamespace(const std::string& ns, ProviderFn fn) {
     std::lock_guard<std::mutex> lk(mx());

--- a/include/gma/engine/ConfigNamespaceRegistry.hpp
+++ b/include/gma/engine/ConfigNamespaceRegistry.hpp
@@ -16,6 +16,12 @@ using ConfigReaderFn = std::function<bool(std::string_view keyTail,
 
 class ConfigNamespaceRegistry {
 public:
+  // Tag instance — see EventTypeRegistry::singleton() for rationale.
+  static ConfigNamespaceRegistry& singleton() {
+    static ConfigNamespaceRegistry s;
+    return s;
+  }
+
   static bool registerNamespace(std::string prefix, ConfigReaderFn reader) {
     std::lock_guard lk(mx());
     auto [it, ok] = map().emplace(std::move(prefix), std::move(reader));

--- a/include/gma/engine/EngineRegistries.hpp
+++ b/include/gma/engine/EngineRegistries.hpp
@@ -3,26 +3,53 @@
 namespace boost::asio { class io_context; }
 
 namespace gma {
+class AtomicProviderRegistry;
 class AtomicStore;
 class Dispatcher;
+class FunctionMap;
 namespace rt   { class ThreadPool; class ShutdownCoordinator; }
-namespace util { struct Config; }
+namespace util { class Config; class Logger; }
 }
 
 namespace gma::engine {
 
-// Handle passed to every IConnector::registerWith() call. Bundles the
-// long-lived engine pieces a connector may need during boot: config, thread
-// pool, store, dispatcher, shutdown coordinator, and the ASIO io_context used
-// for socket work. Static registries (NodeTypeRegistry, FunctionMap, etc.) are
-// accessed through their own singletons and not re-exposed here.
+class ConfigNamespaceRegistry;
+class EventComputerRegistry;
+class EventTypeRegistry;
+class IngressRegistry;
+class NodeTypeRegistry;
+
+// Handle passed to every IConnector::registerWith() call. Bundles every
+// long-lived engine piece a connector may need during boot.
+//
+// The first six fields (cfg / pool / store / dispatcher / shutdown / io)
+// are real per-instance objects owned by main() (or a test fixture).
+//
+// The next eight fields point at the engine's extension-point registries.
+// Most of those registries store all state in private static maps and only
+// expose static methods; the pointer is then "informational" — connectors
+// may dereference it to call static methods through the singleton tag, or
+// invoke the static methods directly. Either is correct. FunctionMap and
+// Logger have real per-instance state and are pointers to their existing
+// process-wide singletons.
 struct EngineRegistries {
+  // ---- Per-instance engine objects ----
   const util::Config*        cfg        { nullptr };
   rt::ThreadPool*            pool       { nullptr };
   AtomicStore*               store      { nullptr };
-  Dispatcher*          dispatcher { nullptr };
+  Dispatcher*                dispatcher { nullptr };
   rt::ShutdownCoordinator*   shutdown   { nullptr };
   boost::asio::io_context*   io         { nullptr };
+
+  // ---- Engine extension-point registries (singletons) ----
+  EventTypeRegistry*         events     { nullptr };
+  EventComputerRegistry*     computers  { nullptr };
+  NodeTypeRegistry*          nodes      { nullptr };
+  IngressRegistry*           ingress    { nullptr };
+  ConfigNamespaceRegistry*   configNs   { nullptr };
+  AtomicProviderRegistry*    providers  { nullptr };
+  FunctionMap*               functions  { nullptr };
+  util::Logger*              log        { nullptr };
 };
 
 } // namespace gma::engine

--- a/include/gma/engine/EventComputerRegistry.hpp
+++ b/include/gma/engine/EventComputerRegistry.hpp
@@ -5,18 +5,26 @@
 #include <string>
 #include <string_view>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 #include "gma/engine/IEventComputer.hpp"
+#include "gma/util/Config.hpp"
 
 namespace gma::engine {
 
 // Registry of **factories** that produce per-dispatcher IEventComputer instances.
-// Dispatchers call createAll() during construction to get their own fresh set of
-// computers — this isolates state (e.g. per-symbol TA histories) between
-// dispatcher instances, which matters in tests that spin up multiple dispatchers.
+// Dispatchers call createAll() on first event of each type to get their own
+// fresh set of computers — this isolates state (e.g. per-symbol TA histories)
+// between dispatcher instances, which matters in tests that spin up multiple
+// dispatchers.
+//
+// Factories receive the dispatcher's util::Config so connector-supplied
+// computers (e.g. MarketTickComputer) can honor per-dispatcher tuning.
+// Connectors that do not need the config can register a no-arg factory via
+// the convenience overload below.
 class EventComputerRegistry {
 public:
-  using Factory = std::function<std::unique_ptr<IEventComputer>()>;
+  using Factory = std::function<std::unique_ptr<IEventComputer>(const util::Config&)>;
 
   // Tag instance — see EventTypeRegistry::singleton() for rationale.
   static EventComputerRegistry& singleton() {
@@ -24,18 +32,28 @@ public:
     return s;
   }
 
-  // Register a factory for an event type. Multiple factories per type are
-  // retained in registration order. Always succeeds.
+  // Register a config-aware factory for an event type. Multiple factories per
+  // type are retained in registration order. Always succeeds.
   static void registerFactory(std::string eventType, Factory factory) {
     if (!factory) return;
     std::lock_guard lk(mx());
     map()[std::move(eventType)].push_back(std::move(factory));
   }
 
+  // Convenience overload: register a no-arg factory. The dispatcher's cfg is
+  // ignored. Useful for tests and computers whose construction is configless.
+  static void registerFactory(std::string eventType,
+                              std::function<std::unique_ptr<IEventComputer>()> nullary) {
+    if (!nullary) return;
+    registerFactory(std::move(eventType),
+                    [f = std::move(nullary)](const util::Config&) { return f(); });
+  }
+
   // Instantiate every registered computer for the given event type, in
-  // registration order. Each call yields fresh instances.
+  // registration order. Each call yields fresh instances. Factories receive
+  // the supplied cfg (default-constructed if omitted).
   static std::vector<std::unique_ptr<IEventComputer>>
-  createAll(std::string_view eventType) {
+  createAll(std::string_view eventType, const util::Config& cfg = util::Config{}) {
     std::vector<Factory> factoriesCopy;
     {
       std::lock_guard lk(mx());
@@ -46,7 +64,7 @@ public:
     std::vector<std::unique_ptr<IEventComputer>> out;
     out.reserve(factoriesCopy.size());
     for (auto& f : factoriesCopy) {
-      if (auto c = f()) out.push_back(std::move(c));
+      if (auto c = f(cfg)) out.push_back(std::move(c));
     }
     return out;
   }

--- a/include/gma/engine/EventComputerRegistry.hpp
+++ b/include/gma/engine/EventComputerRegistry.hpp
@@ -18,6 +18,12 @@ class EventComputerRegistry {
 public:
   using Factory = std::function<std::unique_ptr<IEventComputer>()>;
 
+  // Tag instance — see EventTypeRegistry::singleton() for rationale.
+  static EventComputerRegistry& singleton() {
+    static EventComputerRegistry s;
+    return s;
+  }
+
   // Register a factory for an event type. Multiple factories per type are
   // retained in registration order. Always succeeds.
   static void registerFactory(std::string eventType, Factory factory) {

--- a/include/gma/engine/EventTypeRegistry.hpp
+++ b/include/gma/engine/EventTypeRegistry.hpp
@@ -15,6 +15,14 @@ struct EventSchema {
 
 class EventTypeRegistry {
 public:
+  // Tag instance — registry methods are static, so the singleton is purely a
+  // handle for EngineRegistries to expose. All real storage lives in the
+  // private static map below.
+  static EventTypeRegistry& singleton() {
+    static EventTypeRegistry s;
+    return s;
+  }
+
   static bool registerEvent(EventSchema schema) {
     std::lock_guard lk(mx());
     auto key = schema.name;

--- a/include/gma/engine/IngressRegistry.hpp
+++ b/include/gma/engine/IngressRegistry.hpp
@@ -34,6 +34,12 @@ using IngressFactory = std::function<std::unique_ptr<IIngressSource>(
 
 class IngressRegistry {
 public:
+  // Tag instance — see EventTypeRegistry::singleton() for rationale.
+  static IngressRegistry& singleton() {
+    static IngressRegistry s;
+    return s;
+  }
+
   static bool registerIngress(std::string kind, IngressFactory fn) {
     std::lock_guard lk(mx());
     auto [it, ok] = map().emplace(std::move(kind), std::move(fn));

--- a/include/gma/engine/NodeTypeRegistry.hpp
+++ b/include/gma/engine/NodeTypeRegistry.hpp
@@ -22,6 +22,12 @@ using NodeBuilderFn = std::function<std::shared_ptr<INode>(
 
 class NodeTypeRegistry {
 public:
+  // Tag instance — see EventTypeRegistry::singleton() for rationale.
+  static NodeTypeRegistry& singleton() {
+    static NodeTypeRegistry s;
+    return s;
+  }
+
   static bool registerNodeType(std::string name, NodeBuilderFn fn) {
     std::lock_guard lk(mx());
     auto [it, ok] = map().emplace(std::move(name), std::move(fn));

--- a/include/gma/engine/Registries.hpp
+++ b/include/gma/engine/Registries.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+// Umbrella header for connector authors. Including this brings in IConnector,
+// EngineRegistries, and every engine extension-point registry so a connector
+// implementation can write a single include instead of seven.
+//
+// Engine code should still include the specific headers it needs.
+
+#include "gma/engine/IConnector.hpp"
+#include "gma/engine/EngineRegistries.hpp"
+#include "gma/engine/EventTypeRegistry.hpp"
+#include "gma/engine/EventComputerRegistry.hpp"
+#include "gma/engine/NodeTypeRegistry.hpp"
+#include "gma/engine/IngressRegistry.hpp"
+#include "gma/engine/ConfigNamespaceRegistry.hpp"

--- a/src/core/Dispatcher.cpp
+++ b/src/core/Dispatcher.cpp
@@ -7,25 +7,6 @@
 
 using namespace gma;
 
-namespace {
-// Guarded singleton for the default computer factory. Set once at boot by
-// whichever side owns market-specific computers (main.cpp / test bootstrap /
-// a future MarketConnector::registerWith); read from every dispatcher ctor.
-std::mutex& hookMutex() {
-  static std::mutex m;
-  return m;
-}
-Dispatcher::DefaultComputerFactory& hook() {
-  static Dispatcher::DefaultComputerFactory f;
-  return f;
-}
-} // namespace
-
-void Dispatcher::setDefaultComputerFactory(DefaultComputerFactory f) {
-  std::lock_guard<std::mutex> lk(hookMutex());
-  hook() = std::move(f);
-}
-
 void Dispatcher::addComputer(std::unique_ptr<engine::IEventComputer> c) {
   if (c) _computers.push_back(std::move(c));
 }
@@ -39,19 +20,7 @@ Dispatcher::Dispatcher(rt::ThreadPool* threadPool,
   , _maxHistory(static_cast<std::size_t>(std::max(1, cfg.taHistoryMax)))
   , _maxSymbols(static_cast<std::size_t>(std::max(1, cfg.maxSymbols)))
   , _maxFieldsPerSymbol(static_cast<std::size_t>(std::max(1, cfg.maxFieldsPerSymbol)))
-{
-  DefaultComputerFactory installed;
-  {
-    std::lock_guard<std::mutex> lk(hookMutex());
-    installed = hook();
-  }
-  if (installed) {
-    auto computers = installed(cfg);
-    for (auto& c : computers) {
-      if (c) _computers.push_back(std::move(c));
-    }
-  }
-}
+{}
 
 void Dispatcher::registerListener(const std::string& symbol,
                                         const std::string& field,
@@ -80,16 +49,33 @@ void Dispatcher::unregisterListener(const std::string& symbol,
 void Dispatcher::onTick(const Event& tick) {
   if (tick.symbol.empty() || !tick.payload) return;
 
-  // Invoke every domain computer whose eventType matches this event's type
-  // (defaults to "tick"). TA writes to the store and may notifyListeners on
-  // computed keys (sma_5, rsi_14, …).
-  if (!_computers.empty()) {
-    engine::ComputeContext ctx{ _store, this, _threadPool };
-    for (auto& c : _computers) {
-      if (!c) continue;
-      if (c->eventType() != tick.type) continue;
-      c->compute(tick, ctx);
+  engine::ComputeContext ctx{ _store, this, _threadPool };
+
+  // Per-type cache fed from EventComputerRegistry. First event of a given
+  // type instantiates the registered factories; subsequent events reuse the
+  // cached instances. Late-registered factories are picked up the first time
+  // an event of their type arrives.
+  std::vector<engine::IEventComputer*> typedComputers;
+  {
+    std::lock_guard<std::mutex> lk(_computerCacheMx);
+    auto it = _computersByType.find(tick.type);
+    if (it == _computersByType.end()) {
+      auto fresh = engine::EventComputerRegistry::createAll(tick.type, _cfg);
+      it = _computersByType.emplace(tick.type, std::move(fresh)).first;
     }
+    typedComputers.reserve(it->second.size());
+    for (auto& c : it->second) typedComputers.push_back(c.get());
+  }
+  for (auto* c : typedComputers) {
+    if (c) c->compute(tick, ctx);
+  }
+
+  // Computers added directly via addComputer() — kept for tests and code
+  // paths that want to inject without the global registry.
+  for (auto& c : _computers) {
+    if (!c) continue;
+    if (c->eventType() != tick.type) continue;
+    c->compute(tick, ctx);
   }
 
   // Collect (field, listener) pairs for this symbol under the listener lock.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -88,7 +88,7 @@ int main(int argc, char* argv[]) {
   if (argc > 1) wsPort   = parsePort(argv[1], wsPort);
   if (argc > 3) feedPort = parsePort(argv[3], feedPort);
 
-  // Make CLI overrides authoritative — MarketConnector reads cfg.feedPort.
+  // CLI args win over the config file — connectors read cfg.{wsPort,feedPort}.
   cfg.wsPort   = wsPort;
   cfg.feedPort = feedPort;
 
@@ -99,12 +99,10 @@ int main(int argc, char* argv[]) {
     {{"wsPort", std::to_string(wsPort)}, {"feedPort", std::to_string(feedPort)}}
   );
 
-  // 3) Engine bootstrap: register generic worker functions and node types, and
-  //    install the market-side default-computer-factory hook BEFORE the
-  //    dispatcher is constructed so it picks up a fresh MarketTickComputer.
+  // 3) Engine bootstrap: register generic worker functions and node types.
+  //    Connectors register their own event computers in registerWith().
   gma::registerBuiltinFunctions();
   gma::registerBuiltinNodeTypes();
-  gma::market::MarketConnector::installDefaults();
 
   // 4) Thread pool (global)
   unsigned poolSize = cfg.threadPoolSize > 0

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,10 +11,12 @@
 // -------- Engine --------
 #include "gma/AtomicStore.hpp"
 #include "gma/ExecutionContext.hpp"
+#include "gma/FunctionMap.hpp"
 #include "gma/FunctionRegistry.hpp"
 #include "gma/Dispatcher.hpp"
 #include "gma/NodeRegistry.hpp"
-#include "gma/engine/EngineRegistries.hpp"
+#include "gma/atomic/AtomicProviderRegistry.hpp"
+#include "gma/engine/Registries.hpp"
 #include "gma/rt/ThreadPool.hpp"
 #include "gma/runtime/ShutdownCoordinator.hpp"
 #include "gma/server/WebSocketServer.hpp"
@@ -141,7 +143,15 @@ int main(int argc, char* argv[]) {
   //    order. With one connector today the reverse-order is trivial; the
   //    pattern is future-proof.
   gma::engine::EngineRegistries regs{
-    &cfg, gma::gThreadPool.get(), store.get(), dispatcher.get(), &shutdown, &ioc
+    &cfg, gma::gThreadPool.get(), store.get(), dispatcher.get(), &shutdown, &ioc,
+    &gma::engine::EventTypeRegistry::singleton(),
+    &gma::engine::EventComputerRegistry::singleton(),
+    &gma::engine::NodeTypeRegistry::singleton(),
+    &gma::engine::IngressRegistry::singleton(),
+    &gma::engine::ConfigNamespaceRegistry::singleton(),
+    &gma::AtomicProviderRegistry::singleton(),
+    &gma::FunctionMap::instance(),
+    &gma::util::logger(),
   };
   std::vector<gma::engine::IConnector*> connectors;
   gma::market::MarketConnector marketConnector;

--- a/tests/connectors/SyntheticConnectorTest.cpp
+++ b/tests/connectors/SyntheticConnectorTest.cpp
@@ -5,11 +5,14 @@
 #include "gma/AtomicStore.hpp"
 #include "gma/Dispatcher.hpp"
 #include "gma/Event.hpp"
-#include "gma/engine/EngineRegistries.hpp"
+#include "gma/FunctionMap.hpp"
+#include "gma/atomic/AtomicProviderRegistry.hpp"
+#include "gma/engine/Registries.hpp"
 #include "gma/rt/ThreadPool.hpp"
 #include "gma/runtime/ShutdownCoordinator.hpp"
 #include "gma/synthetic/SyntheticConnector.hpp"
 #include "gma/util/Config.hpp"
+#include "gma/util/Logger.hpp"
 
 #include <boost/asio/io_context.hpp>
 #include <boost/asio/post.hpp>
@@ -87,18 +90,70 @@ TEST(SyntheticConnectorTest, DispatcherRoutesByEventType) {
   EXPECT_FALSE(store.get("SYN", "lastPrice").has_value());
 }
 
-TEST(SyntheticConnectorTest, RegisterWithDrivesIoContext) {
-  // End-to-end: register the connector with a real EngineRegistries, run the
-  // io_context briefly, and verify the timer fired and the computer ran.
+namespace {
+
+// Build a fully-populated EngineRegistries pointing at the supplied per-test
+// engine objects. Mirrors what the composition root does in main().
+engine::EngineRegistries buildRegs(util::Config& cfg,
+                                   rt::ThreadPool& pool,
+                                   AtomicStore& store,
+                                   Dispatcher& dispatcher,
+                                   rt::ShutdownCoordinator& shutdown,
+                                   boost::asio::io_context& ioc) {
+  return engine::EngineRegistries{
+    &cfg, &pool, &store, &dispatcher, &shutdown, &ioc,
+    &engine::EventTypeRegistry::singleton(),
+    &engine::EventComputerRegistry::singleton(),
+    &engine::NodeTypeRegistry::singleton(),
+    &engine::IngressRegistry::singleton(),
+    &engine::ConfigNamespaceRegistry::singleton(),
+    &AtomicProviderRegistry::singleton(),
+    &FunctionMap::instance(),
+    &util::logger(),
+  };
+}
+
+} // namespace
+
+TEST(SyntheticConnectorTest, RegisterWithDoesNotFireTimer) {
+  // Lifecycle invariant: registerWith must allocate but not arm the timer.
+  // Running the io_context after registerWith alone should produce zero
+  // synthetic events, since start() has not been called.
   AtomicStore store;
   rt::ThreadPool pool(1);
   Dispatcher dispatcher(&pool, &store);
   boost::asio::io_context ioc;
-
   util::Config cfg;
   rt::ShutdownCoordinator shutdown;
 
-  engine::EngineRegistries regs{ &cfg, &pool, &store, &dispatcher, &shutdown, &ioc };
+  auto regs = buildRegs(cfg, pool, store, dispatcher, shutdown, ioc);
+
+  synthetic::SyntheticConnector::Options opts;
+  opts.streamKey = "SYN_NOSTART";
+  opts.tickMs    = 1;     // would fire fast if armed.
+  opts.maxTicks  = 5;
+  synthetic::SyntheticConnector connector(opts);
+  connector.registerWith(regs);
+
+  ioc.run_for(std::chrono::milliseconds(50));
+  pool.shutdown();
+
+  EXPECT_FALSE(store.get("SYN_NOSTART", "synthetic.sin").has_value())
+      << "registerWith leaked timer arming — start() should be the only path "
+         "that schedules events";
+}
+
+TEST(SyntheticConnectorTest, StartArmsTimerStopCancels) {
+  // End-to-end lifecycle: registerWith → start fires the timer; stop cancels
+  // any further callbacks. Verifies the post-phase-4 control flow.
+  AtomicStore store;
+  rt::ThreadPool pool(1);
+  Dispatcher dispatcher(&pool, &store);
+  boost::asio::io_context ioc;
+  util::Config cfg;
+  rt::ShutdownCoordinator shutdown;
+
+  auto regs = buildRegs(cfg, pool, store, dispatcher, shutdown, ioc);
 
   synthetic::SyntheticConnector::Options opts;
   opts.streamKey = "SYN_E2E";
@@ -106,12 +161,12 @@ TEST(SyntheticConnectorTest, RegisterWithDrivesIoContext) {
   opts.maxTicks  = 3;
   synthetic::SyntheticConnector connector(opts);
   connector.registerWith(regs);
+  connector.start();
 
-  // Drive the timer until all three ticks fire.
   ioc.run_for(std::chrono::milliseconds(200));
-  shutdown.stop();
+  connector.stop();
   pool.shutdown();
 
-  auto sin0 = store.get("SYN_E2E", "synthetic.sin");
-  ASSERT_TRUE(sin0.has_value()) << "computer never ran — timer didn't dispatch";
+  EXPECT_TRUE(store.get("SYN_E2E", "synthetic.sin").has_value())
+      << "computer never ran — start() didn't arm the timer";
 }

--- a/tests/engine/ConnectorLifecycleTest.cpp
+++ b/tests/engine/ConnectorLifecycleTest.cpp
@@ -1,0 +1,128 @@
+// Pins the IConnector lifecycle contract documented on IConnector.hpp:
+//   1. registerWith() exactly once
+//   2. start() exactly once, after registerWith
+//   3. stop() noexcept, after start; safe to call multiple times
+//   4. multiple connectors stopped in reverse-registration order
+//   5. double-start is a programmer error → throws std::logic_error
+//
+// Uses a hand-rolled MockConnector that records call ordering rather than
+// touching any of the production connectors (their behavior is covered by
+// MarketConnector / SyntheticConnector tests respectively).
+
+#include "gma/engine/IConnector.hpp"
+#include "gma/engine/Registries.hpp"
+
+#include <gtest/gtest.h>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace {
+
+// Mock that appends a tagged string to a shared trace whenever a lifecycle
+// method is called. start() can optionally throw on the second call to
+// exercise case 5.
+class MockConnector final : public gma::engine::IConnector {
+public:
+  MockConnector(std::string tag, std::vector<std::string>* trace)
+    : _tag(std::move(tag)), _trace(trace) {}
+
+  std::string_view name() const override { return _tag; }
+
+  void registerWith(gma::engine::EngineRegistries&) override {
+    ++_registerCalls;
+    _trace->push_back(_tag + ":registerWith");
+  }
+
+  void start() override {
+    if (_started) {
+      throw std::logic_error(_tag + ": double-start");
+    }
+    _started = true;
+    _trace->push_back(_tag + ":start");
+  }
+
+  void stop() noexcept override {
+    // Idempotent: multiple stop() calls are safe and only the first records.
+    if (!_started) return;
+    _started = false;
+    _trace->push_back(_tag + ":stop");
+  }
+
+  int registerCalls() const { return _registerCalls; }
+
+private:
+  std::string _tag;
+  std::vector<std::string>* _trace;
+  bool _started{false};
+  int  _registerCalls{0};
+};
+
+} // namespace
+
+TEST(ConnectorLifecycleTest, RegisterWithCalledExactlyOnce) {
+  std::vector<std::string> trace;
+  MockConnector m("A", &trace);
+  gma::engine::EngineRegistries regs{};
+  m.registerWith(regs);
+  EXPECT_EQ(m.registerCalls(), 1);
+  ASSERT_EQ(trace.size(), 1u);
+  EXPECT_EQ(trace[0], "A:registerWith");
+}
+
+TEST(ConnectorLifecycleTest, StartFollowsRegisterWith) {
+  std::vector<std::string> trace;
+  MockConnector m("A", &trace);
+  gma::engine::EngineRegistries regs{};
+  m.registerWith(regs);
+  m.start();
+  ASSERT_EQ(trace.size(), 2u);
+  EXPECT_EQ(trace[0], "A:registerWith");
+  EXPECT_EQ(trace[1], "A:start");
+}
+
+TEST(ConnectorLifecycleTest, StopOrderIsReverseOfRegistration) {
+  std::vector<std::string> trace;
+  MockConnector a("A", &trace);
+  MockConnector b("B", &trace);
+  gma::engine::EngineRegistries regs{};
+
+  std::vector<gma::engine::IConnector*> connectors{&a, &b};
+  for (auto* c : connectors) c->registerWith(regs);
+  for (auto* c : connectors) c->start();
+  // Reverse-order stop, mirroring main.cpp's "connectors-stop" step.
+  for (auto it = connectors.rbegin(); it != connectors.rend(); ++it) (*it)->stop();
+
+  ASSERT_EQ(trace.size(), 6u);
+  EXPECT_EQ(trace[0], "A:registerWith");
+  EXPECT_EQ(trace[1], "B:registerWith");
+  EXPECT_EQ(trace[2], "A:start");
+  EXPECT_EQ(trace[3], "B:start");
+  // The critical assertion: B stops before A.
+  EXPECT_EQ(trace[4], "B:stop");
+  EXPECT_EQ(trace[5], "A:stop");
+}
+
+TEST(ConnectorLifecycleTest, StopIsIdempotent) {
+  std::vector<std::string> trace;
+  MockConnector m("A", &trace);
+  gma::engine::EngineRegistries regs{};
+  m.registerWith(regs);
+  m.start();
+  m.stop();
+  m.stop();   // second call must not throw and must not record.
+  m.stop();   // third call ditto.
+
+  ASSERT_EQ(trace.size(), 3u);
+  EXPECT_EQ(trace[2], "A:stop");
+}
+
+TEST(ConnectorLifecycleTest, DoubleStartThrowsLogicError) {
+  std::vector<std::string> trace;
+  MockConnector m("A", &trace);
+  gma::engine::EngineRegistries regs{};
+  m.registerWith(regs);
+  m.start();
+  EXPECT_THROW(m.start(), std::logic_error);
+}

--- a/tests/engine/EngineRegistriesShapeTest.cpp
+++ b/tests/engine/EngineRegistriesShapeTest.cpp
@@ -1,0 +1,74 @@
+// Pins the shape of the EngineRegistries struct: every field a connector
+// might rely on must be populatable. The composition root in main.cpp wires
+// real instances; this test wires every field with non-null pointers and
+// verifies they round-trip.
+
+#include "gma/AtomicStore.hpp"
+#include "gma/Dispatcher.hpp"
+#include "gma/FunctionMap.hpp"
+#include "gma/atomic/AtomicProviderRegistry.hpp"
+#include "gma/engine/Registries.hpp"
+#include "gma/rt/ThreadPool.hpp"
+#include "gma/runtime/ShutdownCoordinator.hpp"
+#include "gma/util/Config.hpp"
+#include "gma/util/Logger.hpp"
+
+#include <boost/asio/io_context.hpp>
+#include <gtest/gtest.h>
+
+using namespace gma;
+
+TEST(EngineRegistriesShapeTest, AllFieldsPopulatable) {
+  util::Config cfg;
+  rt::ThreadPool pool(1);
+  AtomicStore store;
+  Dispatcher dispatcher(&pool, &store);
+  rt::ShutdownCoordinator shutdown;
+  boost::asio::io_context ioc;
+
+  engine::EngineRegistries regs{
+    &cfg, &pool, &store, &dispatcher, &shutdown, &ioc,
+    &engine::EventTypeRegistry::singleton(),
+    &engine::EventComputerRegistry::singleton(),
+    &engine::NodeTypeRegistry::singleton(),
+    &engine::IngressRegistry::singleton(),
+    &engine::ConfigNamespaceRegistry::singleton(),
+    &AtomicProviderRegistry::singleton(),
+    &FunctionMap::instance(),
+    &util::logger(),
+  };
+
+  // Per-instance engine objects.
+  EXPECT_EQ(regs.cfg, &cfg);
+  EXPECT_EQ(regs.pool, &pool);
+  EXPECT_EQ(regs.store, &store);
+  EXPECT_EQ(regs.dispatcher, &dispatcher);
+  EXPECT_EQ(regs.shutdown, &shutdown);
+  EXPECT_EQ(regs.io, &ioc);
+
+  // Extension-point registries.
+  EXPECT_NE(regs.events,    nullptr);
+  EXPECT_NE(regs.computers, nullptr);
+  EXPECT_NE(regs.nodes,     nullptr);
+  EXPECT_NE(regs.ingress,   nullptr);
+  EXPECT_NE(regs.configNs,  nullptr);
+  EXPECT_NE(regs.providers, nullptr);
+  EXPECT_NE(regs.functions, nullptr);
+  EXPECT_NE(regs.log,       nullptr);
+
+  // Singleton accessors must return stable references across calls.
+  EXPECT_EQ(&engine::EventTypeRegistry::singleton(),     &engine::EventTypeRegistry::singleton());
+  EXPECT_EQ(&engine::EventComputerRegistry::singleton(), &engine::EventComputerRegistry::singleton());
+  EXPECT_EQ(&engine::NodeTypeRegistry::singleton(),      &engine::NodeTypeRegistry::singleton());
+  EXPECT_EQ(&engine::IngressRegistry::singleton(),       &engine::IngressRegistry::singleton());
+  EXPECT_EQ(&engine::ConfigNamespaceRegistry::singleton(),&engine::ConfigNamespaceRegistry::singleton());
+  EXPECT_EQ(&AtomicProviderRegistry::singleton(),        &AtomicProviderRegistry::singleton());
+}
+
+TEST(EngineRegistriesShapeTest, FieldCountIs14) {
+  // Guard against accidental field removal: sizeof should equal 14 pointers.
+  // (Six per-instance + eight registry pointers, all 8-byte on x86_64.)
+  static_assert(sizeof(engine::EngineRegistries) == 14 * sizeof(void*),
+                "EngineRegistries must carry exactly 14 pointer-sized fields");
+  SUCCEED();
+}

--- a/tests/engine/EventComputerCacheTest.cpp
+++ b/tests/engine/EventComputerCacheTest.cpp
@@ -1,0 +1,111 @@
+// Pins the lazy-cache contract in Dispatcher::onTick: a Dispatcher constructed
+// before a factory is registered must still pick up that factory the first
+// time it sees an event of that type. This is the single biggest invariant
+// the EventComputerRegistry path provides over the old DefaultComputerFactory
+// hook (which only ran in the ctor).
+//
+// Each test uses a unique event type so registry pollution doesn't leak
+// between tests; we never call EventComputerRegistry::clear() (which would
+// wipe the test-bootstrap's "tick" factory and break unrelated tests).
+
+#include "gma/AtomicStore.hpp"
+#include "gma/Dispatcher.hpp"
+#include "gma/Event.hpp"
+#include "gma/engine/EventComputerRegistry.hpp"
+#include "gma/engine/IEventComputer.hpp"
+#include "gma/rt/ThreadPool.hpp"
+#include "gma/util/Config.hpp"
+
+#include <gtest/gtest.h>
+#include <atomic>
+#include <memory>
+#include <string>
+#include <rapidjson/document.h>
+
+using namespace gma;
+
+namespace {
+
+class CountingComputer final : public engine::IEventComputer {
+public:
+  explicit CountingComputer(std::string type, std::atomic<int>* invocations)
+    : _type(std::move(type)), _invocations(invocations) {}
+  std::string_view eventType() const override { return _type; }
+  void compute(const Event&, engine::ComputeContext&) override {
+    if (_invocations) _invocations->fetch_add(1);
+  }
+private:
+  std::string _type;
+  std::atomic<int>* _invocations;
+};
+
+Event makeEvent(const std::string& type, const std::string& sym) {
+  Event e;
+  e.type    = type;
+  e.symbol  = sym;
+  e.payload = std::make_shared<rapidjson::Document>();
+  e.payload->SetObject();
+  return e;
+}
+
+// Each test gets a unique event-type string so factories don't bleed across
+// tests via the (process-wide) EventComputerRegistry singleton.
+std::string uniqueType(const char* tag) {
+  static std::atomic<int> counter{0};
+  return std::string("cache.test.") + tag + "." + std::to_string(counter.fetch_add(1));
+}
+
+} // namespace
+
+TEST(EventComputerCacheTest, LateRegisteredFactoryIsPickedUp) {
+  rt::ThreadPool pool(1);
+  AtomicStore store;
+  Dispatcher dispatcher(&pool, &store);
+
+  // Dispatcher is fully constructed BEFORE we register the factory.
+  // Old behavior: the dispatcher's ctor took a snapshot via the static hook,
+  // so anything registered after construction would never fire. New behavior:
+  // the per-type cache is built lazily on first event, so this must work.
+  const std::string evType = uniqueType("late");
+  std::atomic<int> factoryCalls{0};
+  std::atomic<int> invocations{0};
+
+  engine::EventComputerRegistry::registerFactory(evType, [&] {
+    factoryCalls.fetch_add(1);
+    return std::make_unique<CountingComputer>(evType, &invocations);
+  });
+
+  EXPECT_EQ(factoryCalls.load(), 0);  // factory not invoked yet — lazy.
+  dispatcher.onTick(makeEvent(evType, "X"));
+  EXPECT_EQ(factoryCalls.load(), 1);  // first event of type → factory called.
+  EXPECT_EQ(invocations.load(), 1);
+
+  dispatcher.onTick(makeEvent(evType, "X"));
+  EXPECT_EQ(factoryCalls.load(), 1);  // second event → cache hit, no new factory call.
+  EXPECT_EQ(invocations.load(), 2);   // same instance fired twice.
+}
+
+TEST(EventComputerCacheTest, EachDispatcherGetsFreshInstances) {
+  rt::ThreadPool pool(1);
+  AtomicStore store;
+
+  const std::string evType = uniqueType("fresh");
+  std::atomic<int> factoryCalls{0};
+  std::atomic<int> invocations{0};
+
+  engine::EventComputerRegistry::registerFactory(evType, [&] {
+    factoryCalls.fetch_add(1);
+    return std::make_unique<CountingComputer>(evType, &invocations);
+  });
+
+  Dispatcher d1(&pool, &store);
+  Dispatcher d2(&pool, &store);
+
+  d1.onTick(makeEvent(evType, "X"));
+  d2.onTick(makeEvent(evType, "X"));
+
+  // Each Dispatcher's first event of the type triggers an independent
+  // factory call → two fresh instances, no shared state.
+  EXPECT_EQ(factoryCalls.load(), 2);
+  EXPECT_EQ(invocations.load(), 2);
+}

--- a/tests/engine/RegistriesTest.cpp
+++ b/tests/engine/RegistriesTest.cpp
@@ -125,7 +125,7 @@ TEST(EventComputerRegistryTest, CreateAllOnMissingTypeReturnsEmpty) {
 
 TEST(EventComputerRegistryTest, NullFactoryIgnored) {
   const std::string t = "__test_cr_null__";
-  EventComputerRegistry::registerFactory(t, nullptr);
+  EventComputerRegistry::registerFactory(t, EventComputerRegistry::Factory{});
   EXPECT_EQ(EventComputerRegistry::factoryCount(t), 0u);
 }
 

--- a/tests/test_bootstrap.cpp
+++ b/tests/test_bootstrap.cpp
@@ -1,20 +1,76 @@
 // Runs once per test-binary boot. Registers engine builtins (worker functions
-// and node types) and installs the market connector's default computer factory
-// so every Dispatcher constructed inside any test picks up its own
-// MarketTickComputer.
+// and node types), constructs a process-static MarketConnector, and calls its
+// registerWith() — NOT start(). Tests don't need live sockets, so the feed
+// server / WS clients are constructed but never started. The "tick" event
+// computer factory is registered with EventComputerRegistry as a side effect
+// of registerWith, so every Dispatcher built in any test picks up its own
+// fresh MarketTickComputer the first time it sees a tick.
+
+#include "gma/AtomicStore.hpp"
+#include "gma/Dispatcher.hpp"
+#include "gma/FunctionMap.hpp"
 #include "gma/FunctionRegistry.hpp"
 #include "gma/NodeRegistry.hpp"
+#include "gma/atomic/AtomicProviderRegistry.hpp"
+#include "gma/engine/Registries.hpp"
 #include "gma/market/MarketConnector.hpp"
+#include "gma/rt/ThreadPool.hpp"
+#include "gma/runtime/ShutdownCoordinator.hpp"
+#include "gma/util/Config.hpp"
+#include "gma/util/Logger.hpp"
+
+#include <boost/asio/io_context.hpp>
 #include <gtest/gtest.h>
 
+#include <memory>
+
 namespace {
+
+// Process-static singletons so the connector's captured pointers stay valid
+// for the entire test-binary lifetime.
+struct TestFixtureGlobals {
+  gma::util::Config             cfg;
+  std::unique_ptr<gma::rt::ThreadPool>   pool;
+  std::unique_ptr<gma::AtomicStore>      store;
+  std::unique_ptr<gma::Dispatcher>       dispatcher;
+  std::unique_ptr<gma::rt::ShutdownCoordinator> shutdown;
+  std::unique_ptr<boost::asio::io_context> ioc;
+  std::unique_ptr<gma::market::MarketConnector> market;
+};
+
+TestFixtureGlobals& globals() {
+  static TestFixtureGlobals g;
+  return g;
+}
 
 class BuiltinsEnvironment : public ::testing::Environment {
 public:
   void SetUp() override {
     gma::registerBuiltinFunctions();
     gma::registerBuiltinNodeTypes();
-    gma::market::MarketConnector::installDefaults();
+
+    auto& g = globals();
+    g.pool       = std::make_unique<gma::rt::ThreadPool>(1);
+    g.store      = std::make_unique<gma::AtomicStore>();
+    g.dispatcher = std::make_unique<gma::Dispatcher>(g.pool.get(), g.store.get(), g.cfg);
+    g.shutdown   = std::make_unique<gma::rt::ShutdownCoordinator>();
+    g.ioc        = std::make_unique<boost::asio::io_context>();
+    g.market     = std::make_unique<gma::market::MarketConnector>();
+
+    gma::engine::EngineRegistries regs{
+      &g.cfg, g.pool.get(), g.store.get(), g.dispatcher.get(),
+      g.shutdown.get(), g.ioc.get(),
+      &gma::engine::EventTypeRegistry::singleton(),
+      &gma::engine::EventComputerRegistry::singleton(),
+      &gma::engine::NodeTypeRegistry::singleton(),
+      &gma::engine::IngressRegistry::singleton(),
+      &gma::engine::ConfigNamespaceRegistry::singleton(),
+      &gma::AtomicProviderRegistry::singleton(),
+      &gma::FunctionMap::instance(),
+      &gma::util::logger(),
+    };
+
+    g.market->registerWith(regs);   // NOTE: no start() — tests do not run sockets.
   }
 };
 


### PR DESCRIPTION
Consolidation PR — the four original stacked PRs (#2-#5) each merged into their own stacked base, so only phase 1 landed on master. This PR brings phases 2, 3, and 4 onto master in a single merge.

Equivalent to merging #3 + #4 + #5 in order, all already individually approved.

## Phases included
- **Phase 2** — EngineRegistries 14-field expansion + umbrella include (formerly #3, ENC-55..57, AC3)
- **Phase 3** — Dispatcher reads computers from registry (lazy cache) (formerly #4, ENC-58..61, AC2)
- **Phase 4** — Connector full lifecycle migration; installDefaults removed (formerly #5, ENC-62..69, AC1/4/5/6/7)

## Linear
**Project complete** — every ticket in `connector-lifecycle` is Done.

## Test plan
- [x] `ctest --output-on-failure` — 375/375 pass
- [x] `bench_dispatcher` — 568.865k items/s (baseline 481.369k — improvement)
- [x] `gma_engine` builds without any `connectors/` headers (engine isolation, AC7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)