### PR TITLE
ENC-30: wire ConfigNamespaceRegistry into Config::loadFromFile

### DIFF
--- a/include/gma/util/Config.hpp
+++ b/include/gma/util/Config.hpp
@@ -14,9 +14,20 @@ public:
   // Construct with sensible defaults.
   Config() = default;
 
-  // Load from a simple "key=value" file (unknown keys ignored).
-  // Returns true if file read successfully (even if some keys are unknown).
+  // Load from a simple "key=value" file. Engine-known keys are parsed
+  // directly; everything else is parked in a pending list and forwarded
+  // to ConfigNamespaceRegistry on dispatchPendingKeys() (called after
+  // connectors register their readers in registerWith).
+  // Returns true if the file was read successfully (even if some keys
+  // are unknown to both the engine and any registered namespace).
   bool loadFromFile(const std::string& path);
+
+  // Replay every key parked during loadFromFile through
+  // ConfigNamespaceRegistry::dispatch(). Called by the composition root
+  // after each IConnector::registerWith() has had a chance to register
+  // its namespaces. Returns the number of keys that found a reader; the
+  // remainder are silently dropped (forward-compat for stray keys).
+  std::size_t dispatchPendingKeys();
 
   // --- Public fields (referenced elsewhere in your code) ---
   // TA params (now actually members so those C2039 errors go away)
@@ -95,6 +106,9 @@ public:
 private:
   static bool parseLineKV(const std::string& line, std::string& k, std::string& v);
   static std::string trim(const std::string& s);
+
+  // Parked unknown-to-engine keys awaiting dispatchPendingKeys().
+  std::vector<std::pair<std::string, std::string>> _pendingKeys;
 };
 
 } // namespace util

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -157,6 +157,11 @@ int main(int argc, char* argv[]) {
   connectors.push_back(&marketConnector);
   // (future) gma::crypto::CoinbaseConnector{}.registerWith(regs);
 
+  // Replay any config keys parked during cfg.loadFromFile() through
+  // ConfigNamespaceRegistry now that connectors have registered their
+  // namespaces. Ordering: load → registerWith → dispatchPendingKeys → start.
+  cfg.dispatchPendingKeys();
+
   for (auto* c : connectors) c->start();
   shutdown.registerStep("connectors-stop", 30, [&connectors] {
     for (auto it = connectors.rbegin(); it != connectors.rend(); ++it) {

--- a/src/util/Config.cpp
+++ b/src/util/Config.cpp
@@ -8,6 +8,8 @@
 #include <sstream>
 #include <algorithm>
 
+#include "gma/engine/ConfigNamespaceRegistry.hpp"
+
 #ifdef _WIN32
   #define NOMINMAX
   #include <windows.h>
@@ -187,7 +189,10 @@ bool Config::loadFromFile(const std::string& path) {
       if (taEMA.empty()) taEMA = {12, 26};
     }
     else {
-      // Unknown key; ignore to stay forward-compatible
+      // Unknown to the engine — park for later replay through
+      // ConfigNamespaceRegistry once connectors have registered their
+      // readers. See dispatchPendingKeys().
+      _pendingKeys.emplace_back(std::move(key), std::move(val));
     }
   }
 
@@ -198,6 +203,17 @@ bool Config::loadFromFile(const std::string& path) {
   if (taBBands_stdK <= 0.0) taBBands_stdK = 2.0;
 
   return true;
+}
+
+std::size_t Config::dispatchPendingKeys() {
+  std::size_t consumed = 0;
+  for (const auto& [k, v] : _pendingKeys) {
+    if (gma::engine::ConfigNamespaceRegistry::dispatch(k, v)) {
+      ++consumed;
+    }
+  }
+  _pendingKeys.clear();
+  return consumed;
 }
 
 } // namespace util

--- a/tests/core/ConfigNamespaceDispatchTest.cpp
+++ b/tests/core/ConfigNamespaceDispatchTest.cpp
@@ -1,0 +1,116 @@
+// End-to-end test for ENC-30 (wire ConfigNamespaceRegistry into
+// Config::loadFromFile): a previously-unknown key like "binance.apiKey"
+// must reach a connector-registered ConfigReaderFn through the deferred
+// dispatchPendingKeys() flush, without any change to engine code.
+
+#include "gma/engine/ConfigNamespaceRegistry.hpp"
+#include "gma/util/Config.hpp"
+
+#include <gtest/gtest.h>
+#include <atomic>
+#include <cstdio>
+#include <fstream>
+#include <string>
+
+namespace {
+
+std::string writeTempIni(const std::string& body) {
+  std::string path = std::tmpnam(nullptr);
+  std::ofstream f(path);
+  f << body;
+  f.close();
+  return path;
+}
+
+} // namespace
+
+TEST(ConfigNamespaceDispatchTest, UnknownKeyRoutesToRegisteredNamespace) {
+  // Use a unique prefix so this test doesn't collide with any
+  // production reader the test bootstrap may have registered.
+  const std::string prefix = "enc30test1";
+
+  std::string sawTail;
+  std::string sawValue;
+  std::atomic<int> calls{0};
+
+  gma::engine::ConfigNamespaceRegistry::registerNamespace(prefix,
+    [&](std::string_view tail, std::string_view value) {
+      sawTail.assign(tail);
+      sawValue.assign(value);
+      calls.fetch_add(1);
+      return true;
+    });
+
+  auto path = writeTempIni(prefix + ".apiKey = supersecret\n");
+
+  gma::util::Config cfg;
+  ASSERT_TRUE(cfg.loadFromFile(path));
+  std::remove(path.c_str());
+
+  // Reader is NOT invoked during loadFromFile — keys are parked.
+  EXPECT_EQ(calls.load(), 0);
+
+  std::size_t consumed = cfg.dispatchPendingKeys();
+  EXPECT_EQ(consumed, 1u);
+  EXPECT_EQ(calls.load(), 1);
+  EXPECT_EQ(sawTail, "apiKey");
+  EXPECT_EQ(sawValue, "supersecret");
+}
+
+TEST(ConfigNamespaceDispatchTest, FlatKeysWithoutDotAreNotDispatched) {
+  // ConfigNamespaceRegistry only handles dotted keys (prefix.tail). A flat
+  // key parked by an unknown engine name stays parked but is dropped on
+  // flush — and never reaches a reader.
+  const std::string prefix = "enc30test2";
+  std::atomic<int> calls{0};
+  gma::engine::ConfigNamespaceRegistry::registerNamespace(prefix,
+    [&](std::string_view, std::string_view) { calls.fetch_add(1); return true; });
+
+  auto path = writeTempIni("flatThing = whatever\n");
+  gma::util::Config cfg;
+  ASSERT_TRUE(cfg.loadFromFile(path));
+  std::remove(path.c_str());
+
+  std::size_t consumed = cfg.dispatchPendingKeys();
+  EXPECT_EQ(consumed, 0u);
+  EXPECT_EQ(calls.load(), 0);
+}
+
+TEST(ConfigNamespaceDispatchTest, EngineKnownKeysDoNotPark) {
+  // Keys the engine recognizes (like wsPort) are parsed inline and never
+  // reach the namespace registry, even if a wildcard-ish reader is
+  // registered. This guards against accidental double-handling.
+  const std::string prefix = "wsPort";  // intentionally clashing
+  std::atomic<int> calls{0};
+  gma::engine::ConfigNamespaceRegistry::registerNamespace(prefix,
+    [&](std::string_view, std::string_view) { calls.fetch_add(1); return true; });
+
+  auto path = writeTempIni("wsPort = 9876\n");
+  gma::util::Config cfg;
+  ASSERT_TRUE(cfg.loadFromFile(path));
+  std::remove(path.c_str());
+
+  EXPECT_EQ(cfg.wsPort, 9876);
+  std::size_t consumed = cfg.dispatchPendingKeys();
+  EXPECT_EQ(consumed, 0u);
+  EXPECT_EQ(calls.load(), 0);
+}
+
+TEST(ConfigNamespaceDispatchTest, FlushIsIdempotent) {
+  // Calling dispatchPendingKeys twice consumes once — the second call has
+  // an empty parking list.
+  const std::string prefix = "enc30test4";
+  std::atomic<int> calls{0};
+  gma::engine::ConfigNamespaceRegistry::registerNamespace(prefix,
+    [&](std::string_view, std::string_view) { calls.fetch_add(1); return true; });
+
+  auto path = writeTempIni(prefix + ".x = 1\n" + prefix + ".y = 2\n");
+  gma::util::Config cfg;
+  ASSERT_TRUE(cfg.loadFromFile(path));
+  std::remove(path.c_str());
+
+  EXPECT_EQ(cfg.dispatchPendingKeys(), 2u);
+  EXPECT_EQ(calls.load(), 2);
+  EXPECT_EQ(cfg.dispatchPendingKeys(), 0u);
+  EXPECT_EQ(calls.load(), 2);
+}


### PR DESCRIPTION
First contract-audit ticket. Closes V19: adding `binance.apiKey` no longer requires editing engine files.

## Summary
- `Config::loadFromFile` parks unknown keys in a private vector (was: silent drop).
- New `Config::dispatchPendingKeys()` replays parked keys through `engine::ConfigNamespaceRegistry::dispatch()`. Returns count consumed.
- `main.cpp` orchestration: load → registerWith → dispatchPendingKeys → start.
- New `ConfigNamespaceDispatchTest` (4 cases): unknown dotted key reaches reader after flush; flat keys never dispatch; engine-known keys never park; flush is idempotent.

## Linear
Closes ENC-30.

## Test plan
- [x] 379/379 ctest pass (+4 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)