### PR TITLE
Contract-audit polish batch: ENC-36/37/38/39/40

### DIFF
--- a/connectors/market/src/book/OrderBookManager.cpp
+++ b/connectors/market/src/book/OrderBookManager.cpp
@@ -330,7 +330,7 @@ bool OrderBookManager::onDeleteByVenueKey(const std::string& symbol, const std::
 bool OrderBookManager::onTrade(const std::string& symbol, double tradePrice, uint64_t size, Aggressor aggr) {
     if (gate_(symbol)) { metrics_.incDroppedStale(); return false; }
     if (!validatePrice_(symbol, tradePrice) || !validateSize_(size)) { metrics_.incDroppedMalformed(); return false; }
-    metrics_.incTrades();
+    metrics_.incEvents();
 
     Price tp = toTicks(symbol, tradePrice);
     OrderBook& b = book(symbol);

--- a/include/gma/AtomicStore.hpp
+++ b/include/gma/AtomicStore.hpp
@@ -15,13 +15,13 @@ class AtomicStore {
 public:
   AtomicStore() = default;
 
-  void set(const std::string& symbol, const std::string& field, ArgType value);
+  void set(const std::string& streamKey, const std::string& field, ArgType value);
 
-  /// Write multiple fields for a symbol under a single lock acquisition.
-  void setBatch(const std::string& symbol,
+  /// Write multiple fields for a streamKey under a single lock acquisition.
+  void setBatch(const std::string& streamKey,
                 const std::vector<std::pair<std::string, ArgType>>& fields);
 
-  std::optional<ArgType> get(const std::string& symbol, const std::string& field) const;
+  std::optional<ArgType> get(const std::string& streamKey, const std::string& field) const;
 
 private:
   using FieldMap = std::unordered_map<std::string, ArgType>;

--- a/include/gma/Dispatcher.hpp
+++ b/include/gma/Dispatcher.hpp
@@ -27,11 +27,11 @@ namespace gma {
  * per-field raw-value history so FunctionMap builtins (mean, sum, stddev, …)
  * can be recomputed on each update.
  *
- * Domain-specific computations (market TA, order-book derivations, …) live in
- * IEventComputer implementations sourced from EventComputerRegistry. The
- * dispatcher caches per-type computer instances lazily on first event of
- * each type, so late-registered factories are picked up automatically.
- * Computers may call notifyListeners() to deliver values to subscribers.
+ * Domain-specific computations live in IEventComputer implementations sourced
+ * from EventComputerRegistry. The dispatcher caches per-type computer
+ * instances lazily on first event of each type, so late-registered factories
+ * are picked up automatically. Computers may call notifyListeners() to
+ * deliver values to subscribers.
  */
 class Dispatcher {
 public:

--- a/include/gma/TreeBuilder.hpp
+++ b/include/gma/TreeBuilder.hpp
@@ -39,11 +39,11 @@ namespace tree {
   // ---- Low level builders (used internally & for tests) ----
 
   // Build a single node from JSON spec.
-  //  - defaultSymbol: used when spec omits explicit "symbol"
+  //  - defaultStreamKey: used when spec omits explicit "streamKey"
   //  - downstream   : parent node (may be nullptr at the tail)
   std::shared_ptr<INode> buildOne(
     const rapidjson::Value& spec,
-    const std::string&      defaultSymbol,
+    const std::string&      defaultStreamKey,
     const Deps&             deps,
     std::shared_ptr<INode>  downstream = nullptr
   );
@@ -59,14 +59,14 @@ namespace tree {
   // Build a pipeline from spec → terminal
   std::shared_ptr<INode> buildNode(
     const rapidjson::Value& spec,
-    const std::string&      defaultSymbol,
+    const std::string&      defaultStreamKey,
     const Deps&             deps,
     std::shared_ptr<INode>  terminal
   );
 
   // Build a simple AtomicAccessor, optionally wrapped in an Interval poller
   std::shared_ptr<INode> buildSimple(
-    const std::string&      symbol,
+    const std::string&      streamKey,
     const std::string&      field,
     int                     pollMs,
     const Deps&             deps,

--- a/include/gma/atomic/AtomicProviderRegistry.hpp
+++ b/include/gma/atomic/AtomicProviderRegistry.hpp
@@ -19,7 +19,7 @@ public:
     return s;
   }
 
-  // Register (or replace) a provider function for a namespace, e.g., "ema", "vwap"
+  // Register (or replace) a provider function for a namespace prefix.
   static void registerNamespace(const std::string& ns, ProviderFn fn) {
     std::lock_guard<std::mutex> lk(mx());
     map()[ns] = std::move(fn);

--- a/include/gma/util/Metrics.hpp
+++ b/include/gma/util/Metrics.hpp
@@ -132,7 +132,7 @@ struct MetricsSnapshot {
   uint64_t adds             = 0;
   uint64_t updates          = 0;
   uint64_t deletes          = 0;
-  uint64_t trades           = 0;
+  uint64_t events           = 0;
 
   uint64_t priorities       = 0;   // priority updates
   uint64_t snapshots        = 0;   // snapshot apply calls
@@ -149,13 +149,13 @@ struct MetricsSnapshot {
 
 class Metrics {
 public:
-  // Core book actions
+  // Core action counters
   void incAdds()      { adds_.fetch_add(1, std::memory_order_relaxed); }
   void incUpdates()   { updates_.fetch_add(1, std::memory_order_relaxed); }
   void incDeletes()   { deletes_.fetch_add(1, std::memory_order_relaxed); }
-  void incTrades()    { trades_.fetch_add(1, std::memory_order_relaxed); }
+  void incEvents()    { events_.fetch_add(1, std::memory_order_relaxed); }
 
-  // Book-manager features used in src/book/OrderBookManager.cpp
+  // Domain-specific extensions
   void incPriorities()      { priorities_.fetch_add(1, std::memory_order_relaxed); }
   void incSnapshots()       { snapshots_.fetch_add(1, std::memory_order_relaxed); }
   void incSummaries()       { summaries_.fetch_add(1, std::memory_order_relaxed); }
@@ -177,7 +177,7 @@ public:
     s.adds             = adds_.load(std::memory_order_relaxed);
     s.updates          = updates_.load(std::memory_order_relaxed);
     s.deletes          = deletes_.load(std::memory_order_relaxed);
-    s.trades           = trades_.load(std::memory_order_relaxed);
+    s.events           = events_.load(std::memory_order_relaxed);
 
     s.priorities       = priorities_.load(std::memory_order_relaxed);
     s.snapshots        = snapshots_.load(std::memory_order_relaxed);
@@ -197,7 +197,7 @@ private:
   std::atomic<uint64_t> adds_{0};
   std::atomic<uint64_t> updates_{0};
   std::atomic<uint64_t> deletes_{0};
-  std::atomic<uint64_t> trades_{0};
+  std::atomic<uint64_t> events_{0};
 
   std::atomic<uint64_t> priorities_{0};
   std::atomic<uint64_t> snapshots_{0};

--- a/src/core/AtomicStore.cpp
+++ b/src/core/AtomicStore.cpp
@@ -4,27 +4,27 @@
 
 namespace gma {
 
-void AtomicStore::set(const std::string& symbol, const std::string& field, ArgType value) {
+void AtomicStore::set(const std::string& streamKey, const std::string& field, ArgType value) {
   std::unique_lock lock(_mutex);
-  _data[symbol][field] = std::move(value);
+  _data[streamKey][field] = std::move(value);
 }
 
-void AtomicStore::setBatch(const std::string& symbol,
+void AtomicStore::setBatch(const std::string& streamKey,
                            const std::vector<std::pair<std::string, ArgType>>& fields) {
   std::unique_lock lock(_mutex);
-  auto& fm = _data[symbol];
+  auto& fm = _data[streamKey];
   for (const auto& [key, val] : fields) {
     fm[key] = val;
   }
 }
 
-std::optional<ArgType> AtomicStore::get(const std::string& symbol, const std::string& field) const {
+std::optional<ArgType> AtomicStore::get(const std::string& streamKey, const std::string& field) const {
   std::shared_lock lock(_mutex);
 
-  auto symIt = _data.find(symbol);
-  if (symIt == _data.end()) return std::nullopt;
+  auto skIt = _data.find(streamKey);
+  if (skIt == _data.end()) return std::nullopt;
 
-  const auto& fieldMap = symIt->second;
+  const auto& fieldMap = skIt->second;
   auto fieldIt = fieldMap.find(field);
   if (fieldIt == fieldMap.end()) return std::nullopt;
 

--- a/src/core/TreeBuilder.cpp
+++ b/src/core/TreeBuilder.cpp
@@ -158,19 +158,19 @@ gma::Worker::Fn fnFromName(const rapidjson::Value& spec) {
 namespace gma::tree {
 
 std::shared_ptr<gma::INode> buildOne(const rapidjson::Value& spec,
-                                     const std::string&      defaultSymbol,
+                                     const std::string&      defaultStreamKey,
                                      const Deps&             deps,
                                      std::shared_ptr<gma::INode> downstream);
 
 std::shared_ptr<gma::INode> buildOne(const rapidjson::Value&      spec,
-                                     const std::string&           defaultSymbol,
+                                     const std::string&           defaultStreamKey,
                                      const Deps&                 deps,
                                      std::shared_ptr<gma::INode> downstream) {
   const auto& v    = expectObj(spec, "node");
   const std::string type = expectType(v);
 
   if (const auto* builder = gma::engine::NodeTypeRegistry::find(type)) {
-    return (*builder)(v, defaultSymbol, deps, downstream);
+    return (*builder)(v, defaultStreamKey, deps, downstream);
   }
   throw std::runtime_error("TreeBuilder: unknown node type '" + type + "'");
 }
@@ -181,17 +181,17 @@ std::shared_ptr<gma::INode> buildOne(const rapidjson::Value&      spec,
 
 std::shared_ptr<gma::INode> buildTree(const rapidjson::Value& rootSpec,
                                       const Deps&             deps) {
-  return buildOne(rootSpec, /*defaultSymbol=*/"", deps, /*downstream=*/nullptr);
+  return buildOne(rootSpec, /*defaultStreamKey=*/"", deps, /*downstream=*/nullptr);
 }
 
 std::shared_ptr<gma::INode> buildNode(const rapidjson::Value&      spec,
-                                      const std::string&           defaultSymbol,
+                                      const std::string&           defaultStreamKey,
                                       const Deps&                  deps,
                                       std::shared_ptr<gma::INode>  terminal) {
-  return buildOne(spec, defaultSymbol, deps, std::move(terminal));
+  return buildOne(spec, defaultStreamKey, deps, std::move(terminal));
 }
 
-std::shared_ptr<gma::INode> buildSimple(const std::string&      symbol,
+std::shared_ptr<gma::INode> buildSimple(const std::string&      streamKey,
                                         const std::string&      field,
                                         int                     pollMs,
                                         const Deps&             deps,
@@ -202,7 +202,7 @@ std::shared_ptr<gma::INode> buildSimple(const std::string&      symbol,
     throw std::runtime_error("buildSimple: missing store");
 
   auto accessor =
-    std::make_shared<gma::AtomicAccessor>(symbol, field, deps.store, terminal);
+    std::make_shared<gma::AtomicAccessor>(streamKey, field, deps.store, terminal);
 
   if (pollMs > 0) {
     gma::rt::ThreadPool* pool = deps.pool;
@@ -304,13 +304,13 @@ void registerBuiltinNodeTypes() {
   using gma::engine::NodeBuilderFn;
 
   NodeTypeRegistry::registerNodeType("Listener",
-    [](const rapidjson::Value& v, const std::string& defaultSymbol,
+    [](const rapidjson::Value& v, const std::string& defaultStreamKey,
        const tree::Deps& deps, std::shared_ptr<INode> downstream)
         -> std::shared_ptr<INode> {
       if (!deps.dispatcher || !deps.pool)
         throw std::runtime_error("Listener: missing dispatcher/pool");
 
-      const std::string symbol = strOr(v, "symbol", defaultSymbol);
+      const std::string symbol = strOr(v, "symbol", defaultStreamKey);
       const std::string field  = strOr(v, "field",  "");
       if (symbol.empty())
         throw std::runtime_error("Listener: missing 'symbol'");
@@ -325,7 +325,7 @@ void registerBuiltinNodeTypes() {
     });
 
   NodeTypeRegistry::registerNodeType("Interval",
-    [](const rapidjson::Value& v, const std::string& defaultSymbol,
+    [](const rapidjson::Value& v, const std::string& defaultStreamKey,
        const tree::Deps& deps, std::shared_ptr<INode> downstream)
         -> std::shared_ptr<INode> {
       rt::ThreadPool* pool = deps.pool;
@@ -342,7 +342,7 @@ void registerBuiltinNodeTypes() {
 
       auto child = downstream;
       if (v.HasMember("child"))
-        child = tree::buildOne(v["child"], defaultSymbol, deps, downstream);
+        child = tree::buildOne(v["child"], defaultStreamKey, deps, downstream);
 
       auto interval = std::make_shared<Interval>(
           std::chrono::milliseconds(ms), child, pool);
@@ -351,13 +351,13 @@ void registerBuiltinNodeTypes() {
     });
 
   NodeTypeRegistry::registerNodeType("AtomicAccessor",
-    [](const rapidjson::Value& v, const std::string& defaultSymbol,
+    [](const rapidjson::Value& v, const std::string& defaultStreamKey,
        const tree::Deps& deps, std::shared_ptr<INode> downstream)
         -> std::shared_ptr<INode> {
       if (!deps.store)
         throw std::runtime_error("AtomicAccessor: missing store");
 
-      const std::string symbol = strOr(v, "symbol", defaultSymbol);
+      const std::string symbol = strOr(v, "symbol", defaultStreamKey);
       const std::string field  = strOr(v, "field",  "");
       if (field.empty())
         throw std::runtime_error("AtomicAccessor: missing 'field'");
@@ -374,7 +374,7 @@ void registerBuiltinNodeTypes() {
     });
 
   NodeTypeRegistry::registerNodeType("Aggregate",
-    [](const rapidjson::Value& v, const std::string& defaultSymbol,
+    [](const rapidjson::Value& v, const std::string& defaultStreamKey,
        const tree::Deps& deps, std::shared_ptr<INode> downstream)
         -> std::shared_ptr<INode> {
       std::size_t arity = sizeOr(v, "arity", 0);
@@ -390,7 +390,7 @@ void registerBuiltinNodeTypes() {
       std::vector<std::shared_ptr<INode>> roots;
       roots.reserve(inputArr.Size() + 1);
       for (auto& it : inputArr.GetArray())
-        roots.push_back(tree::buildOne(it, defaultSymbol, deps, agg));
+        roots.push_back(tree::buildOne(it, defaultStreamKey, deps, agg));
       if (roots.empty())
         throw std::runtime_error("Aggregate: empty 'inputs' array");
 
@@ -403,12 +403,16 @@ void registerBuiltinNodeTypes() {
       return std::make_shared<CompositeRoot>(std::move(roots));
     });
 
-  NodeTypeRegistry::registerNodeType("SymbolSplit",
-    [](const rapidjson::Value& v, const std::string& defaultSymbol,
+  // Canonical name "GroupSplit"; "SymbolSplit" registered as a legacy alias
+  // for back-compat with pre-rename request payloads (Q5 of the engine /
+  // connector split decision matrix). Drop the alias when the deprecation
+  // window closes.
+  auto groupSplitBuilder =
+    [](const rapidjson::Value& v, const std::string& defaultStreamKey,
        const tree::Deps& deps, std::shared_ptr<INode> downstream)
         -> std::shared_ptr<INode> {
       if (!v.HasMember("child"))
-        throw std::runtime_error("SymbolSplit: missing 'child'");
+        throw std::runtime_error("GroupSplit: missing 'child'");
 
       // Deep-copy so the factory lambda owns the JSON independently of the
       // caller's stack-local Document.
@@ -416,16 +420,18 @@ void registerBuiltinNodeTypes() {
       childDoc->CopyFrom(v["child"], childDoc->GetAllocator());
 
       GroupSplit::Factory f =
-        [childDoc, defaultSymbol, deps, downstream](const std::string& sym) {
+        [childDoc, defaultStreamKey, deps, downstream](const std::string& sym) {
           return tree::buildOne(*childDoc,
-                                sym.empty() ? defaultSymbol : sym,
+                                sym.empty() ? defaultStreamKey : sym,
                                 deps, downstream);
         };
       return std::make_shared<GroupSplit>(std::move(f));
-    });
+    };
+  NodeTypeRegistry::registerNodeType("GroupSplit", groupSplitBuilder);
+  NodeTypeRegistry::registerNodeType("SymbolSplit", groupSplitBuilder);
 
   NodeTypeRegistry::registerNodeType("Chain",
-    [](const rapidjson::Value& v, const std::string& defaultSymbol,
+    [](const rapidjson::Value& v, const std::string& defaultStreamKey,
        const tree::Deps& deps, std::shared_ptr<INode> downstream)
         -> std::shared_ptr<INode> {
       if (!v.HasMember("stages") || !v["stages"].IsArray())
@@ -438,7 +444,7 @@ void registerBuiltinNodeTypes() {
       auto curDown = downstream;
       for (size_t i = stages.Size(); i > 0; --i) {
         curDown = tree::buildOne(stages[static_cast<rapidjson::SizeType>(i - 1)],
-                                 defaultSymbol, deps, curDown);
+                                 defaultStreamKey, deps, curDown);
       }
       return curDown;
     });

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -88,7 +88,7 @@ int main(int argc, char* argv[]) {
   if (argc > 1) wsPort   = parsePort(argv[1], wsPort);
   if (argc > 3) feedPort = parsePort(argv[3], feedPort);
 
-  // CLI args win over the config file — connectors read cfg.{wsPort,feedPort}.
+  // CLI args win over the config file — engine + connectors read these as-is.
   cfg.wsPort   = wsPort;
   cfg.feedPort = feedPort;
 

--- a/src/nodes/AtomicAccessor.cpp
+++ b/src/nodes/AtomicAccessor.cpp
@@ -22,7 +22,7 @@ void AtomicAccessor::onValue(const StreamValue&) {
   // First check AtomicStore for the field
   auto opt = store_->get(symbol_, field_);
 
-  // If not found in the store, try namespace providers (e.g. "ob.spread")
+  // If not found in the store, try connector-registered namespace providers
   if (!opt.has_value()) {
     auto resolved = AtomicProviderRegistry::tryResolve(symbol_, field_);
     if (resolved.has_value()) {


### PR DESCRIPTION
Five small audit tickets, one branch.

## Tickets
- **ENC-36** — engine `Metrics`: `trades`→`events`, drop "Core book actions" market phrasing; `Dispatcher.hpp` docstring genericized.
- **ENC-37** — engine docstrings: drop `ema`/`vwap`/`ob.spread`/`MarketConnector` examples.
- **ENC-38** — `AtomicStore` public param rename `symbol`→`streamKey`.
- **ENC-39** — `TreeBuilder` `defaultSymbol`→`defaultStreamKey` and `buildSimple` first param rename.
- **ENC-40** — register both `GroupSplit` (canonical) and `SymbolSplit` (legacy alias) at the `NodeTypeRegistry`.

## Linear
Closes ENC-36, ENC-37, ENC-38, ENC-39, ENC-40.

## Test plan
- [x] 379/379 ctest pass — no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)