### PR TITLE
ENC-43 + ENC-44: validator open-vocabulary + AtomicStore caps

### DIFF
--- a/include/gma/AtomicStore.hpp
+++ b/include/gma/AtomicStore.hpp
@@ -15,9 +15,18 @@ class AtomicStore {
 public:
   AtomicStore() = default;
 
+  /// Configure cap enforcement. 0 means unlimited; defaults are unlimited.
+  /// Apply once at boot from the engine Config; thread-safe but expected to
+  /// be a single up-front call before any writes.
+  void setCaps(std::size_t maxStreamKeys, std::size_t maxFieldsPerStreamKey);
+
+  /// Write a single field. Silently dropped if a cap would be exceeded —
+  /// only-on-new-key/new-field; existing entries are always updatable.
   void set(const std::string& streamKey, const std::string& field, ArgType value);
 
   /// Write multiple fields for a streamKey under a single lock acquisition.
+  /// Same cap semantics as set(): drops only the entries that would push past
+  /// a cap; existing entries always update.
   void setBatch(const std::string& streamKey,
                 const std::vector<std::pair<std::string, ArgType>>& fields);
 
@@ -28,6 +37,8 @@ private:
 
   mutable std::shared_mutex _mutex;
   std::unordered_map<std::string, FieldMap> _data;
+  std::size_t _maxStreamKeys{0};         // 0 = unlimited
+  std::size_t _maxFieldsPerStreamKey{0}; // 0 = unlimited
 };
 
 } // namespace gma

--- a/src/core/AtomicStore.cpp
+++ b/src/core/AtomicStore.cpp
@@ -4,16 +4,52 @@
 
 namespace gma {
 
+void AtomicStore::setCaps(std::size_t maxStreamKeys, std::size_t maxFieldsPerStreamKey) {
+  std::unique_lock lock(_mutex);
+  _maxStreamKeys         = maxStreamKeys;
+  _maxFieldsPerStreamKey = maxFieldsPerStreamKey;
+}
+
 void AtomicStore::set(const std::string& streamKey, const std::string& field, ArgType value) {
   std::unique_lock lock(_mutex);
-  _data[streamKey][field] = std::move(value);
+
+  auto skIt = _data.find(streamKey);
+  if (skIt == _data.end()) {
+    if (_maxStreamKeys > 0 && _data.size() >= _maxStreamKeys) {
+      // Cap reached — drop the write rather than evict.
+      return;
+    }
+    skIt = _data.emplace(streamKey, FieldMap{}).first;
+  }
+
+  auto& fm = skIt->second;
+  if (!fm.contains(field)) {
+    if (_maxFieldsPerStreamKey > 0 && fm.size() >= _maxFieldsPerStreamKey) {
+      return;
+    }
+  }
+  fm[field] = std::move(value);
 }
 
 void AtomicStore::setBatch(const std::string& streamKey,
                            const std::vector<std::pair<std::string, ArgType>>& fields) {
   std::unique_lock lock(_mutex);
-  auto& fm = _data[streamKey];
+
+  auto skIt = _data.find(streamKey);
+  if (skIt == _data.end()) {
+    if (_maxStreamKeys > 0 && _data.size() >= _maxStreamKeys) {
+      return;
+    }
+    skIt = _data.emplace(streamKey, FieldMap{}).first;
+  }
+  auto& fm = skIt->second;
+
   for (const auto& [key, val] : fields) {
+    if (!fm.contains(key)) {
+      if (_maxFieldsPerStreamKey > 0 && fm.size() >= _maxFieldsPerStreamKey) {
+        continue;
+      }
+    }
     fm[key] = val;
   }
 }

--- a/src/core/JsonValidator.cpp
+++ b/src/core/JsonValidator.cpp
@@ -71,62 +71,46 @@ void JsonValidator::validateTree(const rapidjson::Value& v, int depth) {
     throw std::runtime_error("Tree node must be an object");
   }
 
-  // Check string field lengths
-  const char* stringFields[] = {"type", "symbol", "field", "node", "function", "fn"};
-  for (const char* sf : stringFields) {
-    if (v.HasMember(sf) && v[sf].IsString()) {
-      if (std::strlen(v[sf].GetString()) > MAX_STRING_LEN) {
+  // Open-vocabulary walk: every member is checked / recursed into based on
+  // its value's type, not its key name. This means connector-introduced
+  // node types with new sub-spec keys get the same length / depth /
+  // array-size checks as engine built-ins, no allowlist edits required.
+  for (auto it = v.MemberBegin(); it != v.MemberEnd(); ++it) {
+    const char* key = it->name.GetString();
+    const auto& val = it->value;
+
+    if (val.IsString()) {
+      if (std::strlen(val.GetString()) > MAX_STRING_LEN) {
         throw std::runtime_error(
-            std::string("field '") + sf + "' exceeds maximum length");
+            std::string("field '") + key + "' exceeds maximum length");
       }
-    }
-  }
-
-  // If this node has a "type" field, validate it as a node
-  if (v.HasMember("type")) {
-    validateNode(v);
-  }
-
-  // Recurse into child nodes
-  if (v.HasMember("child") && v["child"].IsObject()) {
-    validateTree(v["child"], depth + 1);
-  }
-
-  // Recurse into inputs array
-  if (v.HasMember("inputs") && v["inputs"].IsArray()) {
-    const auto& arr = v["inputs"];
-    if (static_cast<int>(arr.Size()) > MAX_ARRAY_SIZE) {
-      throw std::runtime_error("'inputs' array exceeds maximum size of " +
-                               std::to_string(MAX_ARRAY_SIZE));
-    }
-    for (const auto& elem : arr.GetArray()) {
-      if (elem.IsObject()) {
-        validateTree(elem, depth + 1);
-      }
-    }
-  }
-
-  // Recurse into stages/pipeline arrays
-  const char* arrayKeys[] = {"stages", "pipeline"};
-  for (const char* key : arrayKeys) {
-    if (v.HasMember(key) && v[key].IsArray()) {
-      const auto& arr = v[key];
-      if (static_cast<int>(arr.Size()) > MAX_ARRAY_SIZE) {
+    } else if (val.IsObject()) {
+      validateTree(val, depth + 1);
+    } else if (val.IsArray()) {
+      if (static_cast<int>(val.Size()) > MAX_ARRAY_SIZE) {
         throw std::runtime_error(std::string("'") + key +
                                  "' array exceeds maximum size of " +
                                  std::to_string(MAX_ARRAY_SIZE));
       }
-      for (const auto& elem : arr.GetArray()) {
-        if (elem.IsObject()) {
+      for (const auto& elem : val.GetArray()) {
+        if (elem.IsString()) {
+          if (std::strlen(elem.GetString()) > MAX_STRING_LEN) {
+            throw std::runtime_error(
+                std::string("element in array '") + key +
+                "' exceeds maximum length");
+          }
+        } else if (elem.IsObject()) {
           validateTree(elem, depth + 1);
         }
       }
     }
   }
 
-  // Recurse into "node" field
-  if (v.HasMember("node") && v["node"].IsObject()) {
-    validateTree(v["node"], depth + 1);
+  // If this node has a "type" field, look it up in NodeTypeRegistry.
+  // (Length already checked above; here we only verify the type name
+  // resolves to a registered builder.)
+  if (v.HasMember("type")) {
+    validateNode(v);
   }
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -114,7 +114,9 @@ int main(int argc, char* argv[]) {
   shutdown.registerStep("pool-destroy", 85, []{ gma::gThreadPool.reset(); });
 
   // 5) Core components
-  auto store      = std::make_shared<gma::AtomicStore>();
+  auto store = std::make_shared<gma::AtomicStore>();
+  store->setCaps(static_cast<std::size_t>(std::max(0, cfg.maxSymbols)),
+                 static_cast<std::size_t>(std::max(0, cfg.maxFieldsPerSymbol)));
   auto dispatcher = std::make_shared<gma::Dispatcher>(gma::gThreadPool.get(), store.get(), cfg);
 
   // 6) Metrics reporter

--- a/tests/core/AtomicStoreCapsTest.cpp
+++ b/tests/core/AtomicStoreCapsTest.cpp
@@ -1,0 +1,70 @@
+// ENC-44: AtomicStore enforces maxStreamKeys / maxFieldsPerStreamKey
+// directly so writes from any path (Dispatcher, IEventComputer::compute,
+// or external test code) are bounded uniformly.
+
+#include "gma/AtomicStore.hpp"
+
+#include <gtest/gtest.h>
+#include <string>
+
+using namespace gma;
+
+TEST(AtomicStoreCapsTest, NewStreamKeyDroppedWhenAtCap) {
+  AtomicStore store;
+  store.setCaps(/*maxStreamKeys=*/2, /*maxFieldsPerStreamKey=*/0);
+
+  store.set("A", "f1", 1.0);
+  store.set("B", "f1", 2.0);
+  store.set("C", "f1", 3.0);  // exceeds the 2-key cap; dropped silently.
+
+  EXPECT_TRUE(store.get("A", "f1").has_value());
+  EXPECT_TRUE(store.get("B", "f1").has_value());
+  EXPECT_FALSE(store.get("C", "f1").has_value());
+}
+
+TEST(AtomicStoreCapsTest, NewFieldDroppedWhenAtCap) {
+  AtomicStore store;
+  store.setCaps(/*maxStreamKeys=*/0, /*maxFieldsPerStreamKey=*/2);
+
+  store.set("A", "f1", 1.0);
+  store.set("A", "f2", 2.0);
+  store.set("A", "f3", 3.0);  // exceeds the 2-field cap; dropped.
+
+  EXPECT_TRUE(store.get("A", "f1").has_value());
+  EXPECT_TRUE(store.get("A", "f2").has_value());
+  EXPECT_FALSE(store.get("A", "f3").has_value());
+}
+
+TEST(AtomicStoreCapsTest, ExistingEntriesAlwaysUpdate) {
+  // Caps only block adding NEW streamKeys / fields; existing entries
+  // stay updatable even when the store is at cap.
+  AtomicStore store;
+  store.setCaps(/*maxStreamKeys=*/1, /*maxFieldsPerStreamKey=*/1);
+
+  store.set("A", "f1", 1.0);
+  store.set("A", "f1", 99.0);   // same key+field — must update.
+
+  auto v = store.get("A", "f1");
+  ASSERT_TRUE(v.has_value());
+  EXPECT_DOUBLE_EQ(std::get<double>(*v), 99.0);
+}
+
+TEST(AtomicStoreCapsTest, BatchHonorsFieldCapPerCall) {
+  AtomicStore store;
+  store.setCaps(/*maxStreamKeys=*/0, /*maxFieldsPerStreamKey=*/2);
+
+  store.setBatch("A", {{"f1", 1.0}, {"f2", 2.0}, {"f3", 3.0}});
+
+  EXPECT_TRUE(store.get("A", "f1").has_value());
+  EXPECT_TRUE(store.get("A", "f2").has_value());
+  EXPECT_FALSE(store.get("A", "f3").has_value());
+}
+
+TEST(AtomicStoreCapsTest, ZeroCapMeansUnlimited) {
+  AtomicStore store;  // default-constructed = no caps.
+  for (int i = 0; i < 50; ++i) {
+    store.set(std::string("k") + std::to_string(i), "f", static_cast<double>(i));
+  }
+  EXPECT_TRUE(store.get("k0",  "f").has_value());
+  EXPECT_TRUE(store.get("k49", "f").has_value());
+}

--- a/tests/validation/ValidationTest.cpp
+++ b/tests/validation/ValidationTest.cpp
@@ -113,6 +113,59 @@ TEST(JsonValidatorTreeTest, AcceptsValidTree) {
     EXPECT_NO_THROW(JsonValidator::validateTree(d));
 }
 
+// --- Open-vocabulary checks (ENC-43) ---
+//
+// Validator must check string lengths / array sizes / depth on ANY key, not
+// just the engine's pre-allowed set. This guards connector-introduced
+// sub-spec keys (e.g. a future "trade.notes" or "binance.params") from
+// silently bypassing limits.
+
+TEST(JsonValidatorTreeTest, OversizeStringUnderForeignKeyRejected) {
+    // 5000-char string under "tradeNotes" (not in the legacy allowlist).
+    std::string oversize(5000, 'x');
+    std::string json =
+        "{\"type\":\"Worker\",\"fn\":\"sum\",\"tradeNotes\":\"" + oversize + "\"}";
+    auto d = parseDoc(json);
+    try {
+        JsonValidator::validateTree(d);
+        FAIL() << "expected validateTree to throw on oversize foreign-key string";
+    } catch (const std::runtime_error& e) {
+        EXPECT_NE(std::string(e.what()).find("tradeNotes"), std::string::npos)
+            << "error should name the offending key, got: " << e.what();
+    }
+}
+
+TEST(JsonValidatorTreeTest, OversizeArrayUnderForeignKeyRejected) {
+    std::string body = "{\"type\":\"Worker\",\"fn\":\"sum\",\"legs\":[";
+    // MAX_ARRAY_SIZE is 1024 in JsonValidator.cpp; emit 1100 ints.
+    for (int i = 0; i < 1100; ++i) {
+        if (i) body += ",";
+        body += std::to_string(i);
+    }
+    body += "]}";
+    auto d = parseDoc(body);
+    try {
+        JsonValidator::validateTree(d);
+        FAIL() << "expected validateTree to throw on oversize foreign-key array";
+    } catch (const std::runtime_error& e) {
+        EXPECT_NE(std::string(e.what()).find("legs"), std::string::npos)
+            << "error should name the offending key, got: " << e.what();
+    }
+}
+
+TEST(JsonValidatorTreeTest, DeepNestingViaForeignKeyRejected) {
+    // Nest 35 levels deep through a key that isn't in the legacy
+    // recursion allowlist ("foo" instead of "child"/"node"/"inputs").
+    std::string json = "{\"type\":\"Worker\",\"fn\":\"sum\",\"foo\":";
+    for (int i = 0; i < 35; ++i) {
+        json += "{\"type\":\"Worker\",\"fn\":\"sum\",\"foo\":";
+    }
+    json += "{}";
+    for (int i = 0; i < 36; ++i) json += "}";
+    auto d = parseDoc(json);
+    EXPECT_THROW(JsonValidator::validateTree(d), std::runtime_error);
+}
+
 // --- requireMember tests ---
 
 TEST(JsonValidatorRequireMemberTest, ThrowsOnMissing) {


### PR DESCRIPTION
## Summary
- **ENC-43** — `JsonValidator::validateTree` rewritten as a generic member walk; closed allowlists deleted. Connector-introduced sub-spec keys now get length/depth/array-size checks.
- **ENC-44** — `AtomicStore::setCaps()` enforces `maxStreamKeys` / `maxFieldsPerStreamKey` directly; `IEventComputer::compute` writes now honor the same caps the Dispatcher already did.

## Linear
Closes ENC-43, ENC-44.

## Test plan
- [x] 387/387 ctest pass (+3 validator open-vocab cases, +5 AtomicStore caps cases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)