### PR TITLE
ENC-42: Worker::scale into FunctionMap (parametric reducer support)

### DIFF
--- a/include/gma/FunctionMap.hpp
+++ b/include/gma/FunctionMap.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <string>
 #include <functional>
+#include <map>
 #include <unordered_map>
 #include <shared_mutex>
 #include <vector>
@@ -8,20 +9,38 @@
 namespace gma {
 using Func = std::function<double(const std::vector<double>&)>;
 
+/// Parametric function: receives the ordered numeric inputs AND a map of
+/// named numeric parameters extracted from the JSON node spec (e.g.
+/// `factor` for `scale`). Lets callers register reducers that need
+/// per-call tunables without growing dedicated TreeBuilder branches.
+using ParamFunc = std::function<double(const std::vector<double>&,
+                                       const std::map<std::string, double>&)>;
+
 class FunctionMap {
 public:
     static FunctionMap& instance();
 
-    /// Register a new function under `name`.
+    /// Register a new plain reducer under `name`.
     void registerFunction(const std::string& name, Func f);
 
-    /// Lookup a function by name. Throws if not found.
+    /// Register a parametric reducer under `name`. Lookup happens via
+    /// getParamFunction(); plain getFunction() will not surface it.
+    void registerParamFunction(const std::string& name, ParamFunc f);
+
+    /// Lookup a plain reducer by name. Throws if not registered (or is
+    /// only registered as a parametric variant — use getParamFunction).
     Func getFunction(const std::string& name) const;
 
-    /// Returns a snapshot of all registered [name->Func] pairs.
+    /// Lookup a parametric reducer by name. Throws if not registered.
+    ParamFunc getParamFunction(const std::string& name) const;
+
+    /// Returns true if `name` was registered as a parametric reducer.
+    bool isParametric(const std::string& name) const;
+
+    /// Returns a snapshot of all registered plain [name->Func] pairs.
     std::vector<std::pair<std::string, Func>> getAll() const;
 
-    /// Iterate all registered functions under shared_lock without copying.
+    /// Iterate all registered plain reducers under shared_lock without copying.
     /// Callback signature: void(const std::string& name, const Func& fn)
     template <typename Callback>
     void forEach(Callback&& cb) const {
@@ -32,7 +51,8 @@ public:
     }
 
 private:
-    std::unordered_map<std::string, Func> _map;
+    std::unordered_map<std::string, Func>      _map;
+    std::unordered_map<std::string, ParamFunc> _paramMap;
     mutable std::shared_mutex _mutex;
 };
 }

--- a/src/core/BuiltinFunctions.cpp
+++ b/src/core/BuiltinFunctions.cpp
@@ -14,6 +14,21 @@ static constexpr double EPSILON = 1e-6;
 void registerBuiltinFunctions() {
     auto& fm = FunctionMap::instance();
 
+    // ──── Parametric reducers (per-call params from the JSON spec) ────
+
+    // "scale" multiplies the latest input by a per-call `factor` (default 1.0).
+    // Lives here as a ParamFunc rather than getting a hardcoded TreeBuilder
+    // branch — exemplifies how connectors can register their own parametric
+    // reducers without engine edits.
+    fm.registerParamFunction("scale",
+        [](const std::vector<double>& xs,
+           const std::map<std::string, double>& params) -> double {
+            if (xs.empty()) return 0.0;
+            auto it = params.find("factor");
+            double factor = (it == params.end()) ? 1.0 : it->second;
+            return xs.back() * factor;
+        });
+
     // ──── Aggregation (full-vector reductions) ────
 
     fm.registerFunction("mean", [](const std::vector<double>& v) -> double {

--- a/src/core/FunctionMap.cpp
+++ b/src/core/FunctionMap.cpp
@@ -14,11 +14,28 @@ void FunctionMap::registerFunction(const std::string& name, Func f) {
     _map[name] = std::move(f);
 }
 
+void FunctionMap::registerParamFunction(const std::string& name, ParamFunc f) {
+    std::unique_lock lock(_mutex);
+    _paramMap[name] = std::move(f);
+}
+
 Func FunctionMap::getFunction(const std::string& name) const {
     std::shared_lock lock(_mutex);
     auto it = _map.find(name);
     if (it == _map.end()) throw std::runtime_error("Function not found: " + name);
     return it->second;
+}
+
+ParamFunc FunctionMap::getParamFunction(const std::string& name) const {
+    std::shared_lock lock(_mutex);
+    auto it = _paramMap.find(name);
+    if (it == _paramMap.end()) throw std::runtime_error("Parametric function not found: " + name);
+    return it->second;
+}
+
+bool FunctionMap::isParametric(const std::string& name) const {
+    std::shared_lock lock(_mutex);
+    return _paramMap.find(name) != _paramMap.end();
 }
 
 std::vector<std::pair<std::string, Func>> FunctionMap::getAll() const {

--- a/src/core/TreeBuilder.cpp
+++ b/src/core/TreeBuilder.cpp
@@ -119,26 +119,33 @@ gma::Worker::Fn fnFromName(const rapidjson::Value& spec) {
     throw std::runtime_error("Worker: missing 'fn'");
 
   const std::string fn = spec["fn"].GetString();
+  auto& fmap = gma::FunctionMap::instance();
 
-  // "scale" is the only parametric builtin — it reads 'factor' from the spec,
-  // so it can't live in the plain vector<double>->double FunctionMap registry.
-  if (fn == "scale") {
-    double factor =
-      spec.HasMember("factor") && spec["factor"].IsNumber()
-        ? spec["factor"].GetDouble()
-        : 1.0;
-
-    return [factor](Span_t xs) -> gma::ArgType {
-      if (!xs.size()) return gma::ArgType{0.0};
-      const auto& v = xs[xs.size() - 1];
-      return gma::ArgType{toDouble(v) * factor};
+  // Parametric reducer? Extract every numeric spec member as a named
+  // parameter (filtering out structural/well-known keys), bind into the
+  // ParamFunc, and return.
+  if (fmap.isParametric(fn)) {
+    std::map<std::string, double> params;
+    for (auto it = spec.MemberBegin(); it != spec.MemberEnd(); ++it) {
+      const std::string key = it->name.GetString();
+      if (key == "fn" || key == "type" || key == "child" ||
+          key == "node" || key == "inputs" || key == "stages" ||
+          key == "pipeline") continue;
+      if (it->value.IsNumber()) params[key] = it->value.GetDouble();
+    }
+    auto pfn = fmap.getParamFunction(fn);
+    return [pfn, params = std::move(params)](Span_t xs) -> gma::ArgType {
+      std::vector<double> dv;
+      dv.reserve(xs.size());
+      for (const auto& v : xs) dv.push_back(toDouble(v));
+      return gma::ArgType{pfn(dv, params)};
     };
   }
 
-  // Everything else resolves through FunctionMap. Adapts FunctionMap's
+  // Plain reducer: resolve through FunctionMap. Adapts FunctionMap's
   // double(vector<double>) to Worker's ArgType(Span<const ArgType>).
   try {
-    auto mapFn = gma::FunctionMap::instance().getFunction(fn);
+    auto mapFn = fmap.getFunction(fn);
     return [mapFn](Span_t xs) -> gma::ArgType {
       std::vector<double> dv;
       dv.reserve(xs.size());

--- a/tests/mapping/FunctionMapTest.cpp
+++ b/tests/mapping/FunctionMapTest.cpp
@@ -18,6 +18,40 @@ TEST(FunctionMapTest, RegisterAndRetrieve) {
     EXPECT_DOUBLE_EQ(sumFn(data), 6.0);
 }
 
+// ENC-42: FunctionMap supports parametric reducers — `scale` lives here as
+// a ParamFunc and the engine no longer carries a hardcoded TreeBuilder
+// branch for it.
+TEST(FunctionMapTest, ParametricFunctionRegisterAndRetrieve) {
+    auto& fm = FunctionMap::instance();
+    fm.registerParamFunction("biased_sum",
+        [](const std::vector<double>& xs,
+           const std::map<std::string, double>& params) -> double {
+            double bias = 0.0;
+            auto it = params.find("bias");
+            if (it != params.end()) bias = it->second;
+            double s = 0.0;
+            for (double x : xs) s += x;
+            return s + bias;
+        });
+
+    EXPECT_TRUE(fm.isParametric("biased_sum"));
+    EXPECT_FALSE(fm.isParametric("sumTest"));
+
+    auto pfn = fm.getParamFunction("biased_sum");
+    std::vector<double> xs{1.0, 2.0, 3.0};
+    EXPECT_DOUBLE_EQ(pfn(xs, {{"bias", 10.0}}), 16.0);
+    EXPECT_DOUBLE_EQ(pfn(xs, {}), 6.0);  // missing param → default 0.
+}
+
+TEST(FunctionMapTest, ScaleIsParametricBuiltin) {
+    auto& fm = FunctionMap::instance();
+    ASSERT_TRUE(fm.isParametric("scale"));
+    auto pfn = fm.getParamFunction("scale");
+    EXPECT_DOUBLE_EQ(pfn({2.0, 4.0}, {{"factor", 3.0}}), 12.0);   // 4 * 3
+    EXPECT_DOUBLE_EQ(pfn({5.0}, {}), 5.0);                        // default 1.0
+    EXPECT_DOUBLE_EQ(pfn({}, {{"factor", 7.0}}), 0.0);            // empty input
+}
+
 TEST(FunctionMapTest, OverwriteFunction) {
     auto& fm = FunctionMap::instance();
     // Initial registration returns 1.0


### PR DESCRIPTION
## Summary
- `FunctionMap` adds a `ParamFunc` registry — reducers that need per-call params (extracted from the JSON spec).
- `scale` registers as a `ParamFunc`; the hardcoded `if (fn == "scale")` branch in `TreeBuilder::fnFromName` is deleted. `TreeBuilder` consults `isParametric()` and harvests numeric spec members into the params map.

## Linear
Closes ENC-42.

## Test plan
- [x] 389/389 ctest pass (+2 new FunctionMap parametric cases). Existing `scale` corpus tests pass without modification — same observable behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)