### PR TITLE
ENC-94: docs/atomic-keys.md (bare vs ob.* namespaces)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,6 +120,7 @@ See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for the full picture including 
 - Test files named `<Component>Test.cpp` under `tests/<category>/`; the gtest binary is a single `gma_tests` executable
 - Connectors implement the strict `IConnector` lifecycle: `registerWith()` allocates and registers (no live sockets/timers), `start()` brings sources online, `stop()` noexcept tears down in reverse order. The composition root drives all three; never wire your own `ShutdownCoordinator` step from inside a connector.
 - **Ingress sources are engine-owned (ENC-31).** Connectors register named factories on `reg.ingress` (e.g. `market.feedserver`, `market.wsclient`); the composition root reads `cfg.ingress[]` and instantiates them. Adding a new ingress kind is a factory registration + INI edit, not a `main.cpp` change. Legacy `feedPort` / `feedUrl` / `feeds.N.*` keys are auto-translated into `cfg.ingress[]` entries with a one-release deprecation warn.
+- **Atomic-key namespaces — bare vs `ob.*` (ENC-94).** Two distinct namespaces by source: bare (`bid`, `ask`, `lastPrice`, sma_N, ...) is written by `MarketTickComputer` only when the tick payload carries the field directly (pre-aggregated tick connectors). `ob.*` (`ob.best.bid.price`, `ob.spread`, ...) is computed from `OrderBookManager` state and is the right answer for L2/L3 sources (ITCH, FIX). Full vocabulary + decision rule in [`docs/atomic-keys.md`](docs/atomic-keys.md).
 
 ## Configuration
 

--- a/docs/atomic-keys.md
+++ b/docs/atomic-keys.md
@@ -1,0 +1,105 @@
+# Atomic keys — bare vs `ob.*` (ENC-94)
+
+GMA exposes two distinct atomic-key namespaces. Subscribers must pick
+the right one for the data source they're behind, or they'll get
+silence.
+
+> **Background:** the 2026-05-01 PoC subscribed to bare `bid` against
+> `feed-sim.v3m.xyz` (an ITCH 5.0 feed) and received zero updates,
+> while bare `lastPrice` worked fine. This doc explains why and what
+> to subscribe to instead.
+
+## The split
+
+| Namespace | Source | When it fires |
+|---|---|---|
+| **bare** (`lastPrice`, `bid`, `ask`, `spread`, `volume`, ...) | `MarketTickComputer::compute` (in the market connector) | Only when the inbound tick payload carries that JSON field directly. Driven by `MarketFieldMap.bidFields`/`askFields`/etc. — i.e. **pre-aggregated tick connectors**. |
+| **`ob.*`** (`ob.best.bid.price`, `ob.spread`, `ob.mid`, ...) | `ob::Provider` via `AtomicProviderRegistry::registerNamespace("ob", …)` | Always available when the market connector is wired and the order book has any state. **Derived from `OrderBookManager`** — the right answer for L2/L3 sources like ITCH/FIX. |
+
+The split is intentional. It preserves the distinction between "the
+feed told us this value" and "we computed this from order-book state."
+Conflating them would lose information that matters when debugging
+data quality.
+
+## Decision rule
+
+| Your feed source emits ... | Subscribe to |
+|---|---|
+| Pre-aggregated ticks with explicit `bid`/`ask`/`lastPrice` JSON fields | **bare** keys |
+| Raw L2/L3 messages (ITCH, FIX, OUCH) | **`ob.*`** keys for top-of-book / depth |
+| Both (some feeds carry both NBBO ticks AND raw books) | bare for tick fields, `ob.*` for depth-derived metrics |
+
+Never subscribe to both for the same conceptual value — they may
+disagree, and the disagreement is meaningful (your tick was stale or
+your book is stale).
+
+## Bare-key vocabulary
+
+Tick fields written by `MarketTickComputer` when the tick payload
+contains them under a name listed in `MarketFieldMap`:
+
+- `lastPrice`, `openPrice`, `highPrice`, `lowPrice`, `prevClose`
+- `bid`, `ask`, `spread`
+- `volume`, `obv`, `vwap`
+- `mean`, `median`
+- `timestamp`
+
+TA indicators computed by `MarketTickComputer` from price/volume
+history (parameters from `Config.ta*`):
+
+- `sma_<n>` (e.g. `sma_5`, `sma_20`)
+- `ema_<n>` (e.g. `ema_12`, `ema_26`)
+- `rsi_<n>` (e.g. `rsi_14`)
+- `atr_<n>`, `momentum_<n>`, `roc_<n>`, `volume_avg_<n>`
+- `macd.line`, `macd.signal`, `macd.histogram`
+- `bb.upper`, `bb.middle`, `bb.lower`, `bb.width`
+- `volatility_rank`
+
+## `ob.*` vocabulary
+
+Top-of-book and book-derived metrics from `ob::Provider`. Canonical
+list (transcribed from
+`connectors/market/include/gma/ob/ObKeysCatalog.hpp`):
+
+- `ob.best.bid.price`, `ob.best.bid.size`
+- `ob.best.ask.price`, `ob.best.ask.size`
+- `ob.spread`, `ob.mid`
+- `ob.cum.bid.levels.10.size`
+- `ob.cum.ask.levels.10.size`
+- `ob.imbalance.levels.1-10`
+- `ob.vwap.bid.levels.1-10`
+- `ob.vwap.ask.levels.1-10`
+- `ob.meta.seq`, `ob.meta.is_stale`
+
+> **Keep in sync with `ObKeysCatalog.hpp`.** This page is hand-
+> transcribed; if you add an `ob.*` key, update both. A regen tool
+> would be welcome but isn't shipped.
+
+## Example: PoC against `feed-sim.v3m.xyz`
+
+```ini
+# gma.conf — ITCH source, so use ob.* for top-of-book
+ingress.0.kind = market.feedserver
+ingress.0.port = 9001
+ingress.1.kind = market.wsclient
+ingress.1.url  = wss://feed-sim.v3m.xyz/feed
+ingress.1.adapter = itch
+ingress.1.symbols = NEXO,VALT,RAYM,STRT,DRRB
+```
+
+```jsonc
+// WS subscribe — pick fields that match the source
+{
+  "type": "subscribe",
+  "requests": [
+    {"key": 1, "streamKey": "NEXO", "field": "lastPrice"},          // bare — works (trade events)
+    {"key": 2, "streamKey": "NEXO", "field": "ob.best.bid.price"},  // ob.*  — works (book derived)
+    {"key": 3, "streamKey": "NEXO", "field": "ob.spread"},          // ob.*  — works
+    {"key": 4, "streamKey": "NEXO", "field": "bid"}                 // bare — silent (ITCH has no bid field)
+  ]
+}
+```
+
+The first three return value updates; the fourth never fires because
+ITCH doesn't carry a JSON `bid` field — the order-book derivation is
+the only signal source.

--- a/specs/2026-05-01-atomic-keys-doc/SPEC.md
+++ b/specs/2026-05-01-atomic-keys-doc/SPEC.md
@@ -1,0 +1,120 @@
+# SPEC: document atomic-key namespaces (bare vs ob.*)
+
+**Slug:** atomic-keys-doc · **Date:** 2026-05-01 · **Status:** Approved
+**Repo:** GMA_V3 (+ customer-layer touch) · **Linear:** ENC-94
+
+## Problem
+
+The 2026-05-01 PoC subscribed to bare `bid` / `ask` against the
+`feed-sim.v3m.xyz` ITCH feed and got nothing — those fields stay
+empty because `MarketTickComputer` only writes them when the feed
+payload carries `bid`/`ask` JSON keys directly (pre-aggregated
+ticks). For raw L2/L3 sources like ITCH, top-of-book data lives
+under the `ob.*` namespace (`ob.best.bid.price`, `ob.spread`, etc.)
+served by `ob::Provider`. The split is intentional but undocumented;
+nothing tells a user (or the AI compile prompt) which to use when.
+
+## Proposed change
+
+Doc-only. Add `gma_v3/docs/atomic-keys.md` describing the two
+namespaces, their sources, the full `ob.*` catalog, and when to
+pick which. Surface a pointer from `CLAUDE.md`. Update
+`customer-layer/apps/server/src/services/ai-compile-prompt.ts` so
+Claude knows to ask for `ob.best.bid.price` against L2 sources
+rather than bare `bid`.
+
+## Scope
+
+- New `gma_v3/docs/atomic-keys.md` covering:
+  - The two namespaces and the design intent (preserve "feed gave us
+    this" vs "we derived this from order-book state").
+  - Bare key vocabulary: `lastPrice`, `openPrice`, `highPrice`,
+    `lowPrice`, `prevClose`, `mean`, `median`, `volume`, `obv`,
+    `vwap`, `bid`, `ask`, `spread`, `timestamp`, plus the TA
+    indicators (sma_N / ema_N / rsi_N / macd.* / bb.* / atr.N /
+    momentum.N / roc.N / volume_avg.N / volatility_rank).
+  - `ob.*` vocabulary: full transcription of
+    `ObKeysCatalog::canonicalKeys` so the doc stays the single
+    discoverable source.
+  - Decision rule: pre-aggregated tick connector ⇒ bare; L2/L3
+    ⇒ `ob.*`; never both for the same field.
+- `gma_v3/CLAUDE.md` Code Conventions: one bullet pointing at
+  `docs/atomic-keys.md`.
+- `customer-layer/apps/server/src/services/ai-compile-prompt.ts`:
+  rewrite the "Atomic keys directly subscribable in the field"
+  section of `SCHEMA_REFERENCE` to:
+  - List the bare keys with a one-line "from pre-aggregated feeds"
+    annotation.
+  - List the `ob.*` keys with "from L2/L3 sources (ITCH, FIX, etc.)".
+  - Tell Claude: when the user asks for bid/ask/spread on a feed
+    described as "ITCH", "L2", or unspecified, prefer `ob.*`; only
+    use bare when the user names a pre-aggregated source.
+
+## Non-goals
+
+- **No code in MarketTickComputer.** No alias path that resolves
+  bare `bid` to `ob.best.bid.price`. The namespace split is
+  intentional design, not a UX wart.
+- **No new atomic keys.** Pure documentation of what already exists.
+- **No breaking change to either namespace.** Bare keys still fire
+  exactly when they fired before; `ob.*` is unchanged.
+- **No automatic schema generation.** `ObKeysCatalog.hpp` is
+  authoritative for the `ob.*` list; this doc duplicates it once
+  with a note to keep them in sync. Generator tooling is a
+  separate ticket if it ever matters.
+- **No customer-layer test changes.** The AI compile prompt change
+  doesn't break any existing test (tests mock the LLM call).
+
+## Acceptance criteria
+
+1. `gma_v3/docs/atomic-keys.md` exists and contains both vocabulary
+   lists plus the decision rule.
+2. `gma_v3/CLAUDE.md` has a one-line bullet referencing
+   `docs/atomic-keys.md`.
+3. `customer-layer/apps/server/src/services/ai-compile-prompt.ts`'s
+   `SCHEMA_REFERENCE` mentions `ob.best.bid.price`, `ob.best.ask.price`,
+   `ob.spread`, `ob.mid` explicitly.
+4. The doc page transcribes every entry in
+   `connectors/market/include/gma/ob/ObKeysCatalog.hpp::canonicalKeys`,
+   verifiable by spot check.
+5. A re-run of the 2026-05-01 PoC client subscribing to
+   `(NEXO, ob.best.bid.price)` against feed-sim produces non-zero
+   updates in 30 s. (Validates the doc's claim is accurate, not
+   just plausible.)
+
+## Constraints
+
+- **Performance:** none — doc.
+- **Compatibility:** none broken. Bare `bid`/`ask` continues to
+  fire under the same conditions as before.
+- **Dependencies:** AC5 reuses ENC-99's PoC client.
+
+## Affected systems
+
+- `gma_v3/docs/atomic-keys.md` (new)
+- `gma_v3/CLAUDE.md` (one-line addition)
+- `customer-layer/apps/server/src/services/ai-compile-prompt.ts`
+  (rewrite the atomic-keys section of SCHEMA_REFERENCE)
+
+## Alternatives considered
+
+- **Wire bid/ask through MarketTickComputer from the OB.** Rejected:
+  conflates "feed told us" with "we derived" — exactly the
+  distinction the field-map was designed to preserve. Adds a runtime
+  dependency from MarketTickComputer to OrderBookManager.
+- **Alias `bid` → `ob.best.bid.price` at AtomicAccessor lookup.**
+  Rejected: same conflation, with the additional cost of a
+  surprising keyspace.
+- **Auto-generate the doc from ObKeysCatalog.hpp.** Rejected as
+  premature; transcribe once and add a sync note.
+
+## Risks
+
+- **Doc rot.** `ObKeysCatalog.hpp` could grow without the doc
+  catching up. Mitigation: a one-line "Keep in sync with
+  ObKeysCatalog.hpp" footer at the top of the section, plus the
+  AC5 PoC re-run as a coarse smoke.
+
+## Open questions
+
+- None.


### PR DESCRIPTION
Doc-only. Closes ENC-94 (gma_v3 half).