### PR TITLE
mvp-deploy-prep follow-up: Dockerfile installs rapidjson-dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libboost-system-dev \
     libboost-thread-dev \
     libssl-dev \
+    rapidjson-dev \
  && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /src


### PR DESCRIPTION
## Summary
The initial GMA_V3 Dockerfile (PR #17) only installed Boost + OpenSSL build deps; the CMakeLists requires RapidJSON which isn't transitive through Boost on Debian. \`apt install rapidjson-dev\` resolves it.

## Verified
\`podman build -f GMA_V3/Dockerfile -t gma_v3:dev .\` from the workspace root — image builds clean.