### PR TITLE
ENC-293: BucketTime node — wall-clock-aligned periodic tick source

### DIFF
--- a/include/gma/NodeRegistry.hpp
+++ b/include/gma/NodeRegistry.hpp
@@ -3,9 +3,10 @@
 namespace gma {
 
 // Register engine-provided node builders (Listener, Worker, Aggregate, Interval,
-// AtomicAccessor, GroupSplit, Chain) with NodeTypeRegistry. The "SymbolSplit"
-// JSON wire name is retained as an alias for GroupSplit for backward
-// compatibility. Idempotent on duplicates — safe to call multiple times.
+// BucketTime, AtomicAccessor, GroupSplit, Chain) with NodeTypeRegistry. The
+// "SymbolSplit" JSON wire name is retained as an alias for GroupSplit for
+// backward compatibility. Idempotent on duplicates — safe to call multiple
+// times.
 void registerBuiltinNodeTypes();
 
 } // namespace gma

--- a/include/gma/nodes/BucketTime.hpp
+++ b/include/gma/nodes/BucketTime.hpp
@@ -1,0 +1,71 @@
+#pragma once
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <memory>
+#include <mutex>
+#include <thread>
+#include "gma/nodes/INode.hpp"
+#include "gma/rt/ThreadPool.hpp"
+
+namespace gma {
+
+// Wall-clock-aligned periodic tick source.
+//
+// Differs from gma::Interval in one critical way: BucketTime emits each
+// tick on the wall-clock period boundary rather than `period` after the
+// previous tick. With period=60000 (one minute), ticks fire at
+// 00:00:00, 00:01:00, 00:02:00, ... regardless of when the node was
+// constructed. With period=1000, ticks fire at the .000 of each
+// second.
+//
+// Why this exists: GMA pipelines that produce 1-minute OHLC candles
+// or 1-minute volume buckets need every consumer to bucket on the
+// same boundary so a "1m bar" means the same wall-clock window across
+// the data plane. Using Interval(60000ms) here would drift relative
+// to the wall clock — clients connecting at different moments would
+// receive slightly-shifted buckets. BucketTime guarantees alignment.
+//
+// The ThreadPool / shutdown / shared_from_this contract matches
+// Interval (see Interval.hpp). shutdown() is synchronous; the timer
+// thread is joined (or detached safely if shutdown is called from the
+// timer thread itself).
+class BucketTime final : public INode,
+                         public std::enable_shared_from_this<BucketTime> {
+public:
+  BucketTime(std::chrono::milliseconds period,
+             std::shared_ptr<INode> child,
+             gma::rt::ThreadPool* pool);
+
+  ~BucketTime();
+
+  // Must be called after construction when owned by a shared_ptr.
+  void start();
+
+  void onValue(const StreamValue&) override; // no-op (source node)
+  void shutdown() noexcept override;
+
+  // Returns the next wall-clock instant aligned to `period` that lies
+  // strictly after `from` (when `from` is itself on a boundary, the
+  // result is the *next* boundary, never `from`). Public for direct
+  // testing — no state, pure function of the inputs.
+  static std::chrono::system_clock::time_point nextAlignedAfter(
+      std::chrono::system_clock::time_point from,
+      std::chrono::milliseconds period);
+
+private:
+  void timerLoop();
+
+  const std::chrono::milliseconds period_;
+  std::shared_ptr<INode> child_;
+  gma::rt::ThreadPool* pool_;
+
+  std::atomic<bool> stopping_{false};
+  std::atomic<bool> started_{false};
+
+  std::mutex mx_;
+  std::condition_variable cv_;
+  std::thread timerThread_;
+};
+
+} // namespace gma

--- a/src/core/TreeBuilder.cpp
+++ b/src/core/TreeBuilder.cpp
@@ -14,6 +14,7 @@
 #include "gma/nodes/Worker.hpp"
 #include "gma/nodes/AtomicAccessor.hpp"
 #include "gma/nodes/Interval.hpp"
+#include "gma/nodes/BucketTime.hpp"
 
 // Runtime deps
 #include "gma/AtomicStore.hpp"
@@ -364,6 +365,36 @@ void registerBuiltinNodeTypes() {
           std::chrono::milliseconds(ms), child, pool);
       interval->start();
       return interval;
+    });
+
+  // BucketTime emits ticks aligned to wall-clock period boundaries (e.g.
+  // ms=60000 ticks at every minute boundary regardless of when the node
+  // was constructed). Same JSON shape as Interval — pipelines that need
+  // alignment swap "Interval" for "BucketTime" without other changes.
+  NodeTypeRegistry::registerNodeType("BucketTime",
+    [](const rapidjson::Value& v, const std::string& defaultStreamKey,
+       const tree::Deps& deps, std::shared_ptr<INode> downstream)
+        -> std::shared_ptr<INode> {
+      rt::ThreadPool* pool = deps.pool;
+      if (!pool && gThreadPool) pool = gThreadPool.get();
+      if (!pool)
+        throw std::runtime_error("BucketTime: no thread pool available");
+
+      int ms = intOr(v, "ms", intOr(v, "periodMs", 0));
+      if (ms <= 0)
+        throw std::runtime_error("BucketTime: positive 'ms' required");
+      static constexpr int MAX_BUCKET_MS = 3600000;
+      if (ms > MAX_BUCKET_MS)
+        throw std::runtime_error("BucketTime: 'ms' exceeds maximum (3600000)");
+
+      auto child = downstream;
+      if (v.HasMember("child"))
+        child = tree::buildOne(v["child"], defaultStreamKey, deps, downstream);
+
+      auto bucket = std::make_shared<BucketTime>(
+          std::chrono::milliseconds(ms), child, pool);
+      bucket->start();
+      return bucket;
     });
 
   NodeTypeRegistry::registerNodeType("AtomicAccessor",

--- a/src/nodes/BucketTime.cpp
+++ b/src/nodes/BucketTime.cpp
@@ -1,0 +1,104 @@
+#include "gma/nodes/BucketTime.hpp"
+#include "gma/util/Logger.hpp"
+
+namespace gma {
+
+BucketTime::BucketTime(std::chrono::milliseconds period,
+                       std::shared_ptr<INode> child,
+                       gma::rt::ThreadPool* pool)
+  : period_(period), child_(std::move(child)), pool_(pool)
+{
+}
+
+BucketTime::~BucketTime() {
+  stopping_.store(true, std::memory_order_release);
+  cv_.notify_all();
+  if (timerThread_.joinable()) {
+    if (timerThread_.get_id() == std::this_thread::get_id()) {
+      timerThread_.detach();
+    } else {
+      timerThread_.join();
+    }
+  }
+}
+
+void BucketTime::start() {
+  bool expected = false;
+  if (!started_.compare_exchange_strong(expected, true))
+    return;
+
+  timerThread_ = std::thread([self = shared_from_this()] {
+    self->timerLoop();
+  });
+}
+
+std::chrono::system_clock::time_point
+BucketTime::nextAlignedAfter(
+    std::chrono::system_clock::time_point from,
+    std::chrono::milliseconds period) {
+  using namespace std::chrono;
+  // Compute (epoch ms / period) * period + period — the next strictly-
+  // greater wall-clock multiple of `period`.
+  const auto epoch_ms = duration_cast<milliseconds>(from.time_since_epoch()).count();
+  const auto period_ms = period.count();
+  if (period_ms <= 0) {
+    // Defensive — caller shouldn't pass non-positive periods. Return
+    // `from` so the caller sleeps zero and re-evaluates.
+    return from;
+  }
+  const auto next_ms = ((epoch_ms / period_ms) + 1) * period_ms;
+  return system_clock::time_point{milliseconds{next_ms}};
+}
+
+void BucketTime::timerLoop() {
+  while (true) {
+    if (stopping_.load(std::memory_order_acquire))
+      break;
+
+    const auto now = std::chrono::system_clock::now();
+    const auto target = nextAlignedAfter(now, period_);
+    {
+      std::unique_lock<std::mutex> lk(mx_);
+      // wait_until lets shutdown wake us early without re-arming.
+      if (cv_.wait_until(lk, target, [this] {
+            return stopping_.load(std::memory_order_acquire);
+          })) {
+        break;
+      }
+    }
+    if (stopping_.load(std::memory_order_acquire))
+      break;
+    if (!child_) break;
+
+    try {
+      if (pool_) {
+        auto c = child_;
+        pool_->post([c] { c->onValue(StreamValue{"", 0.0}); });
+      } else {
+        child_->onValue(StreamValue{"", 0.0});
+      }
+    } catch (const std::exception& ex) {
+      gma::util::logger().log(gma::util::LogLevel::Error,
+        "BucketTime::timerLoop: onValue exception",
+        {{"err", ex.what()}});
+    }
+  }
+}
+
+void BucketTime::onValue(const StreamValue&) {
+  // source node: no upstream input
+}
+
+void BucketTime::shutdown() noexcept {
+  stopping_.store(true, std::memory_order_release);
+  cv_.notify_all();
+  if (timerThread_.joinable()) {
+    if (timerThread_.get_id() == std::this_thread::get_id()) {
+      timerThread_.detach();
+    } else {
+      timerThread_.join();
+    }
+  }
+}
+
+} // namespace gma

--- a/tests/nodes/BucketTimeTest.cpp
+++ b/tests/nodes/BucketTimeTest.cpp
@@ -1,0 +1,170 @@
+// Tests for gma::BucketTime — wall-clock-aligned periodic tick source.
+//
+// The alignment guarantee is the load-bearing property: every consumer
+// of a BucketTime(60000) ticks at the same wall-clock minute boundary,
+// so a "1m bar" means the same window across the whole data plane.
+// These tests use shorter periods (10–100 ms) to keep runtime tight
+// while still exercising the alignment math.
+
+#include "gma/nodes/BucketTime.hpp"
+#include "gma/rt/ThreadPool.hpp"
+#include "gma/nodes/INode.hpp"
+#include <gtest/gtest.h>
+#include <atomic>
+#include <chrono>
+#include <memory>
+#include <thread>
+#include <vector>
+
+using namespace gma;
+using namespace std::chrono;
+using namespace std::chrono_literals;
+
+namespace {
+
+// Captures (count, timestamps) per onValue. Timestamps let us verify
+// alignment to wall-clock period boundaries.
+class TimestampingStub : public INode {
+public:
+    std::atomic<int> count{0};
+    std::vector<system_clock::time_point> ticks;
+    std::mutex mx;
+    void onValue(const StreamValue&) override {
+        std::lock_guard<std::mutex> lk(mx);
+        ++count;
+        ticks.push_back(system_clock::now());
+    }
+    void shutdown() noexcept override {}
+};
+
+} // namespace
+
+TEST(BucketTimeTest, EmitsAtLeastOnceWithinTwoPeriods) {
+    rt::ThreadPool pool(1);
+    auto stub = std::make_shared<TimestampingStub>();
+    auto bt = std::make_shared<BucketTime>(20ms, stub, &pool);
+    bt->start();
+    std::this_thread::sleep_for(50ms);
+    int cnt = stub->count.load();
+    EXPECT_GE(cnt, 1) << "Expected at least 1 tick within 2 periods, got " << cnt;
+    bt->shutdown();
+    pool.shutdown();
+}
+
+TEST(BucketTimeTest, ShutdownStopsTicks) {
+    rt::ThreadPool pool(1);
+    auto stub = std::make_shared<TimestampingStub>();
+    auto bt = std::make_shared<BucketTime>(15ms, stub, &pool);
+    bt->start();
+    std::this_thread::sleep_for(40ms);
+    bt->shutdown();
+    int before = stub->count.load();
+    std::this_thread::sleep_for(45ms);
+    int after = stub->count.load();
+    EXPECT_EQ(after, before) << "Count should not increase after shutdown";
+    pool.shutdown();
+}
+
+// The alignment property: ticks land at wall-clock multiples of the
+// period (within a small tolerance for kernel scheduling jitter). With
+// period=100ms we expect every tick's epoch_ms % 100 to be near zero.
+TEST(BucketTimeTest, TicksAlignToWallClockPeriod) {
+    rt::ThreadPool pool(1);
+    auto stub = std::make_shared<TimestampingStub>();
+    constexpr auto period = 100ms;
+    auto bt = std::make_shared<BucketTime>(period, stub, &pool);
+    bt->start();
+    std::this_thread::sleep_for(550ms); // ~5 ticks expected
+    bt->shutdown();
+
+    std::vector<system_clock::time_point> snapshot;
+    {
+        std::lock_guard<std::mutex> lk(stub->mx);
+        snapshot = stub->ticks;
+    }
+    ASSERT_GE(snapshot.size(), 3u) << "Need at least 3 ticks to verify alignment";
+
+    constexpr long tolerance_ms = 25; // generous for slow CI / loaded box
+    for (size_t i = 0; i < snapshot.size(); ++i) {
+        const auto epoch_ms = duration_cast<milliseconds>(
+            snapshot[i].time_since_epoch()).count();
+        const auto offset = epoch_ms % period.count();
+        // Distance from the boundary (it's never negative; offset is in
+        // [0, period_ms)).
+        const auto delta = std::min(offset, period.count() - offset);
+        EXPECT_LE(delta, tolerance_ms)
+            << "tick[" << i << "] offset=" << offset << "ms from boundary";
+    }
+    pool.shutdown();
+}
+
+// Two BucketTime nodes constructed at slightly different moments still
+// fire on the SAME wall-clock boundaries (the property Interval cannot
+// provide). Confirms alignment is a function of the wall clock, not
+// the node's start time.
+TEST(BucketTimeTest, TwoBucketTimesShareBoundary) {
+    rt::ThreadPool pool(2);
+    auto stub1 = std::make_shared<TimestampingStub>();
+    auto stub2 = std::make_shared<TimestampingStub>();
+    constexpr auto period = 50ms;
+    auto bt1 = std::make_shared<BucketTime>(period, stub1, &pool);
+    bt1->start();
+    std::this_thread::sleep_for(13ms); // off-period
+    auto bt2 = std::make_shared<BucketTime>(period, stub2, &pool);
+    bt2->start();
+    std::this_thread::sleep_for(220ms);
+    bt1->shutdown();
+    bt2->shutdown();
+
+    std::vector<system_clock::time_point> ticks1, ticks2;
+    {
+        std::lock_guard<std::mutex> lk(stub1->mx);
+        ticks1 = stub1->ticks;
+    }
+    {
+        std::lock_guard<std::mutex> lk(stub2->mx);
+        ticks2 = stub2->ticks;
+    }
+    ASSERT_FALSE(ticks1.empty());
+    ASSERT_FALSE(ticks2.empty());
+
+    // For every tick from bt2, find the closest tick from bt1; they
+    // should be within scheduling jitter, NOT 13ms apart (which is what
+    // Interval would produce).
+    constexpr long jitter_ms = 25;
+    for (const auto& t2 : ticks2) {
+        long minDiff = std::numeric_limits<long>::max();
+        for (const auto& t1 : ticks1) {
+            const long d = std::abs(duration_cast<milliseconds>(t1 - t2).count());
+            if (d < minDiff) minDiff = d;
+        }
+        EXPECT_LE(minDiff, jitter_ms)
+            << "bt2 tick is " << minDiff << "ms from nearest bt1 tick — alignment broken";
+    }
+    pool.shutdown();
+}
+
+TEST(BucketTimeTest, NextAlignedAfterReturnsStrictlyGreaterMultiple) {
+    using TP = system_clock::time_point;
+    using MS = milliseconds;
+    constexpr auto period = MS{100};
+
+    // Mid-bucket: now=12345 should yield 12400.
+    {
+        const auto now = TP{MS{12345}};
+        const auto next = BucketTime::nextAlignedAfter(now, period);
+        EXPECT_EQ(duration_cast<MS>(next.time_since_epoch()).count(), 12400);
+    }
+    // On-boundary: now=12300 should yield the *next* boundary, 12400.
+    {
+        const auto now = TP{MS{12300}};
+        const auto next = BucketTime::nextAlignedAfter(now, period);
+        EXPECT_EQ(duration_cast<MS>(next.time_since_epoch()).count(), 12400);
+    }
+    // Just past boundary: now=12301 should yield 12400.
+    {
+        const auto now = TP{MS{12301}};
+        const auto next = BucketTime::nextAlignedAfter(now, period);
+        EXPECT_EQ(duration_cast<MS>(next.time_since_epoch()).count(), 12400);
+    }
+}


### PR DESCRIPTION
## Summary

New `gma::BucketTime` node + JSON registration in `TreeBuilder`. Mirrors `Interval`'s class shape and shutdown contract, but **emits ticks aligned to wall-clock period boundaries** rather than \`period\` after the previous tick. With `ms=60000` (one minute), ticks fire at 00:00:00, 00:01:00, ... regardless of when the node was constructed.

## Why

GMA pipelines that produce 1-minute OHLC candles or 1-minute volume buckets need every consumer to bucket on the same boundary so a "1m bar" means the same wall-clock window across the data plane. Using `Interval(60000)` drifts relative to the wall clock — clients connecting at different moments would receive shifted buckets. `BucketTime` guarantees alignment.

**This unblocks ENC-279** (forum seeds `scene_state` for the saved-chart slice) — the seed needs `Listener(SYMBOL.lastPrice clock) → BucketTime(60000) → Aggregate(N) → Worker(<reducer>) → Responder` × 4 (one each for OHLC O/H/L/C, plus one for bucketed volume sum).

## Files

- **`include/gma/nodes/BucketTime.hpp`** — declaration; mirrors `Interval`'s `shared_from_this` + `ThreadPool` + cv-based shutdown contract. `nextAlignedAfter` is exposed (public, pure, stateless) so the unit test can pin the alignment math directly.
- **`src/nodes/BucketTime.cpp`** — timer thread uses `cv_.wait_until(target)` where `target = ((epoch_ms / period) + 1) * period`. Identical detach-vs-join guard on shutdown that `Interval` uses to avoid self-deadlock when `shutdown()` is called from the timer thread itself.
- **`src/core/TreeBuilder.cpp`** — registers `"BucketTime"` with the same JSON shape as `Interval`: `{type:"BucketTime", ms:N, child:{...}}`. Same MAX 3600000ms cap. Pipelines that need alignment swap `"Interval"` for `"BucketTime"` without other changes.
- **`tests/nodes/BucketTimeTest.cpp`** — 5 cases (see Test plan).
- **`include/gma/NodeRegistry.hpp`** — doc-comment update.

## Out of scope

Per-symbol OHLC + bucketed-volume pipeline JSON templates. Those are forum-authored payloads on top of this node, landing in ENC-279.

## Test plan

Verified inside `localhost/gma-builddeps:dev` podman image (host has no cmake/boost):

- [x] Configure (cmake) — clean.
- [x] Build (`gma_engine`, `gma_server`, `gma_tests`) — clean.
- [x] `./gma_tests --gtest_filter='BucketTimeTest.*'` — **5/5 pass**:
  - `EmitsAtLeastOnceWithinTwoPeriods` — basic ticking
  - `ShutdownStopsTicks` — stop semantics
  - `TicksAlignToWallClockPeriod` — every emitted timestamp is within 25ms of a 100ms boundary (the load-bearing alignment property)
  - `TwoBucketTimesShareBoundary` — two BucketTime nodes constructed 13ms apart still fire on the same wall-clock boundaries (the property `Interval` cannot provide)
  - `NextAlignedAfterReturnsStrictlyGreaterMultiple` — direct pin of the alignment math
- [x] `./gma_tests` (full suite) — **414/414 pass**; no regression in existing nodes.

## Linear

ENC-293 (https://linear.app/encultured/issue/ENC-293) — filed by ENC-292 audit. **Unblocks ENC-279** (forum seed) which in turn unblocks ENC-282 (seed verification) and ENC-288 (full-stack smoke).

🤖 Generated with [Claude Code](https://claude.com/claude-code)