### PR TITLE
feed-sim-connector phase 2: gma_v3 pulls connectors from forum at startup

### DIFF
--- a/docs/CONNECTOR_REFACTOR.md
+++ b/docs/CONNECTOR_REFACTOR.md
@@ -125,6 +125,18 @@ at priority 35 stops them in reverse. Adding a new ingress kind is a
 factory registration in some connector's `registerWith` plus an
 `ingress.N.kind = …` line in the INI — no `main.cpp` change.
 
+**Forum-driven ingress (feed-sim-connector phase 2).** Ingress entries
+no longer have to come from the INI: when `cfg.forumUrl` (or the
+`FORUM_URL` env var) is non-empty, the composition root calls
+`gma::forum::ConnectorsClient::fetchIngresses(forumUrl, tenantId,
+authToken)` after `synthesizeIngressFromLegacy()` and *replaces*
+`cfg.ingress` with the result. Each connector row from forum's
+`/api/connectors` becomes a `market.wsclient` ingress (one per
+`protocol == "itch"` row with a non-empty `endpoint_url`). Failure to
+reach forum aborts startup — see fail-fast acceptance criterion in the
+proposal SPEC. The static INI ingress remains the authoritative source
+in forum-less dev runs.
+
 ```cpp
 int main(int argc, char* argv[]) {
   // ... engine bootstrap (config, threadpool, store, dispatcher, ioc) ...

--- a/include/gma/forum/ConnectorsClient.hpp
+++ b/include/gma/forum/ConnectorsClient.hpp
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "gma/util/Config.hpp"
+
+namespace gma {
+namespace forum {
+
+/// Synchronous one-shot HTTP(S) GET against forum's /api/connectors,
+/// translating each connector row into a Config::Ingress entry that
+/// the engine's IngressRegistry can dispatch on.
+///
+/// Lives in the engine library (no connector dep) because the call
+/// produces ingress configuration *before* connectors register their
+/// factories — it's part of the composition root's startup sequence.
+///
+/// Exits the process on failure (per spec AC-6, fail-fast). Use the
+/// parser helper directly in tests to assert the JSON-to-ingress
+/// mapping without touching a network.
+class ConnectorsClient {
+public:
+  /// Fetch connectors for `tenantId` from `forumUrl`'s `/api/connectors`
+  /// endpoint and translate each `protocol == "itch"` entry into a
+  /// `market.wsclient` ingress with `url` / `adapter` / `symbols`
+  /// params filled from the row. Connectors with empty `endpoint_url`
+  /// or unknown protocols are skipped (logged at Warn).
+  ///
+  /// `forumUrl` accepts `http://` and `https://` schemes; the path is
+  /// always `/api/connectors`. `tenantId` becomes the `X-Tenant-Id`
+  /// header. `bearer` becomes `Authorization: Bearer <bearer>` —
+  /// pass empty to skip auth (dev only).
+  ///
+  /// Throws `std::runtime_error` on transport / parse / auth failure.
+  /// Caller (main.cpp) is expected to log + exit.
+  static std::vector<gma::util::Config::Ingress>
+  fetchIngresses(const std::string& forumUrl,
+                 const std::string& tenantId,
+                 const std::string& bearer);
+
+  /// Pure parser entry point — consumes a JSON body shaped like
+  /// `[{name, endpoint_url, protocol, symbols, ...}]` and returns
+  /// the corresponding ingress entries. Used by both `fetchIngresses`
+  /// (after the network round-trip) and by `ConnectorsClientTest` so
+  /// the JSON-to-ingress mapping is exercised without a network.
+  static std::vector<gma::util::Config::Ingress>
+  parseConnectorsJson(const std::string& body);
+};
+
+} // namespace forum
+} // namespace gma

--- a/include/gma/util/Config.hpp
+++ b/include/gma/util/Config.hpp
@@ -113,6 +113,16 @@ public:
   };
   std::vector<Ingress> ingress;
 
+  // forum-driven ingress (feed-sim-connector phase 2).
+  // When forumUrl is non-empty the composition root replaces the static
+  // `ingress[]` with the result of `gma::forum::ConnectorsClient::
+  // fetchIngresses(forumUrl, forumTenantId, forumAuthToken)` after the
+  // INI is loaded but before connectors start. Empty values disable
+  // the pull (legacy INI ingress remains authoritative).
+  std::string forumUrl;
+  std::string forumTenantId;
+  std::string forumAuthToken;
+
 private:
   static bool parseLineKV(const std::string& line, std::string& k, std::string& v);
   static std::string trim(const std::string& s);

--- a/src/forum/ConnectorsClient.cpp
+++ b/src/forum/ConnectorsClient.cpp
@@ -1,0 +1,294 @@
+#include "gma/forum/ConnectorsClient.hpp"
+
+#include "gma/util/Logger.hpp"
+
+#include <chrono>
+#include <regex>
+#include <sstream>
+#include <stdexcept>
+#include <thread>
+
+#include <boost/asio.hpp>
+#include <boost/asio/connect.hpp>
+#include <boost/asio/ip/tcp.hpp>
+#include <boost/beast/core.hpp>
+#include <boost/beast/http.hpp>
+#include <boost/beast/version.hpp>
+
+#ifdef GMA_HAS_SSL
+#include <boost/asio/ssl.hpp>
+#include <boost/beast/ssl.hpp>
+#endif
+
+#include <rapidjson/document.h>
+#include <rapidjson/error/en.h>
+
+namespace beast = boost::beast;
+namespace http = boost::beast::http;
+namespace asio = boost::asio;
+using tcp = boost::asio::ip::tcp;
+
+namespace gma {
+namespace forum {
+
+namespace {
+
+// ParsedURL: the bits of a forumUrl that the HTTP request needs.
+struct ParsedURL {
+  bool tls = false;
+  std::string host;
+  std::string port;
+  std::string target = "/";
+};
+
+ParsedURL parseUrl(const std::string& url) {
+  // Loose-but-sufficient regex; we only ever feed this user-controlled
+  // INI strings, not arbitrary input. Path and query land in `target`.
+  static const std::regex re(R"(^(http|https)://([^/:?]+)(?::(\d+))?(/[^?]*)?(\?.*)?$)",
+                             std::regex::ECMAScript);
+  std::smatch m;
+  if (!std::regex_match(url, m, re)) {
+    throw std::runtime_error("ConnectorsClient: malformed forumUrl: " + url);
+  }
+  ParsedURL out;
+  out.tls = (m[1].str() == "https");
+  out.host = m[2].str();
+  if (m[3].matched && !m[3].str().empty()) {
+    out.port = m[3].str();
+  } else {
+    out.port = out.tls ? "443" : "80";
+  }
+  std::string path = m[4].matched ? m[4].str() : std::string{"/"};
+  if (path.empty()) path = "/";
+  out.target = path;
+  if (m[5].matched) out.target += m[5].str();
+  return out;
+}
+
+// Build the HTTP GET request shared by both legs (plain + TLS).
+http::request<http::empty_body>
+buildRequest(const ParsedURL& url,
+             const std::string& tenantId,
+             const std::string& bearer) {
+  std::string apiTarget = url.target;
+  if (!apiTarget.empty() && apiTarget.back() == '/') {
+    apiTarget.pop_back();
+  }
+  apiTarget += "/api/connectors";
+
+  http::request<http::empty_body> req{http::verb::get, apiTarget, 11};
+  req.set(http::field::host, url.host + (url.port == "80" || url.port == "443" ? "" : ":" + url.port));
+  req.set(http::field::user_agent, std::string("gma_v3/") + BOOST_BEAST_VERSION_STRING);
+  req.set(http::field::accept, "application/json");
+  if (!tenantId.empty()) {
+    req.set("X-Tenant-Id", tenantId);
+  }
+  if (!bearer.empty()) {
+    req.set(http::field::authorization, "Bearer " + bearer);
+  }
+  return req;
+}
+
+// Synchronous plain-HTTP GET → response body.
+std::string fetchPlain(const ParsedURL& url,
+                       const std::string& tenantId,
+                       const std::string& bearer) {
+  asio::io_context ioc;
+  tcp::resolver resolver{ioc};
+  beast::tcp_stream stream{ioc};
+
+  auto endpoints = resolver.resolve(url.host, url.port);
+  stream.expires_after(std::chrono::seconds(5));
+  stream.connect(endpoints);
+
+  auto req = buildRequest(url, tenantId, bearer);
+  http::write(stream, req);
+
+  beast::flat_buffer buffer;
+  http::response<http::string_body> res;
+  http::read(stream, buffer, res);
+
+  beast::error_code ec;
+  stream.socket().shutdown(tcp::socket::shutdown_both, ec);
+
+  if (res.result() != http::status::ok) {
+    throw std::runtime_error(
+        "ConnectorsClient: HTTP " + std::to_string(static_cast<int>(res.result())) +
+        " from forum: " + std::string(res.body()).substr(0, 200));
+  }
+  return std::string(res.body());
+}
+
+#ifdef GMA_HAS_SSL
+// Synchronous TLS-HTTPS GET → response body.
+std::string fetchTls(const ParsedURL& url,
+                     const std::string& tenantId,
+                     const std::string& bearer) {
+  asio::io_context ioc;
+  asio::ssl::context ctx{asio::ssl::context::tls_client};
+  ctx.set_default_verify_paths();
+  ctx.set_verify_mode(asio::ssl::verify_peer);
+
+  tcp::resolver resolver{ioc};
+  beast::ssl_stream<beast::tcp_stream> stream{ioc, ctx};
+
+  if (!SSL_set_tlsext_host_name(stream.native_handle(), url.host.c_str())) {
+    beast::error_code ec{static_cast<int>(::ERR_get_error()), asio::error::get_ssl_category()};
+    throw std::runtime_error("ConnectorsClient: SNI failure: " + ec.message());
+  }
+
+  auto endpoints = resolver.resolve(url.host, url.port);
+  beast::get_lowest_layer(stream).expires_after(std::chrono::seconds(10));
+  beast::get_lowest_layer(stream).connect(endpoints);
+  stream.handshake(asio::ssl::stream_base::client);
+
+  auto req = buildRequest(url, tenantId, bearer);
+  http::write(stream, req);
+
+  beast::flat_buffer buffer;
+  http::response<http::string_body> res;
+  http::read(stream, buffer, res);
+
+  beast::error_code ec;
+  stream.shutdown(ec);
+  // SSL_R_SHORT_READ is a benign close per Beast docs.
+
+  if (res.result() != http::status::ok) {
+    throw std::runtime_error(
+        "ConnectorsClient: HTTP " + std::to_string(static_cast<int>(res.result())) +
+        " from forum: " + std::string(res.body()).substr(0, 200));
+  }
+  return std::string(res.body());
+}
+#endif
+
+// Best-effort retry around a single fetch lambda. Total budget ~14s
+// across 3 attempts (2s, 4s, 8s) — matches the spec's "small retry
+// loop" risk mitigation.
+template <typename F>
+std::string fetchWithRetry(F&& fetch) {
+  std::string lastErr;
+  for (int attempt = 0; attempt < 3; ++attempt) {
+    try {
+      return fetch();
+    } catch (const std::exception& ex) {
+      lastErr = ex.what();
+      gma::util::logger().log(
+          gma::util::LogLevel::Warn,
+          "forum.connectors.fetch_retry",
+          {{"attempt", std::to_string(attempt + 1)}, {"err", lastErr}});
+      std::this_thread::sleep_for(std::chrono::seconds(1 << (attempt + 1)));
+    }
+  }
+  throw std::runtime_error("ConnectorsClient: exhausted retries: " + lastErr);
+}
+
+} // namespace
+
+std::vector<gma::util::Config::Ingress>
+ConnectorsClient::parseConnectorsJson(const std::string& body) {
+  rapidjson::Document doc;
+  if (doc.Parse(body.c_str()).HasParseError()) {
+    throw std::runtime_error(
+        std::string("ConnectorsClient: JSON parse error: ") +
+        rapidjson::GetParseError_En(doc.GetParseError()));
+  }
+  if (!doc.IsArray()) {
+    throw std::runtime_error("ConnectorsClient: expected JSON array at top level");
+  }
+
+  std::vector<gma::util::Config::Ingress> out;
+  out.reserve(doc.Size());
+
+  for (rapidjson::SizeType i = 0; i < doc.Size(); ++i) {
+    const auto& row = doc[i];
+    if (!row.IsObject()) continue;
+
+    const std::string name = (row.HasMember("name") && row["name"].IsString())
+                                 ? row["name"].GetString() : std::string{};
+    const std::string protocol = (row.HasMember("protocol") && row["protocol"].IsString())
+                                     ? row["protocol"].GetString() : std::string{};
+    const std::string endpoint = (row.HasMember("endpointUrl") && row["endpointUrl"].IsString())
+                                     ? row["endpointUrl"].GetString() : std::string{};
+
+    if (protocol.empty() || endpoint.empty()) {
+      gma::util::logger().log(
+          gma::util::LogLevel::Warn,
+          "forum.connectors.skipped",
+          {{"name", name}, {"reason", "missing protocol or endpoint_url"}});
+      continue;
+    }
+
+    if (protocol != "itch") {
+      gma::util::logger().log(
+          gma::util::LogLevel::Warn,
+          "forum.connectors.unknown_protocol",
+          {{"name", name}, {"protocol", protocol}});
+      continue;
+    }
+
+    // Symbols → comma-joined string param (matches the existing
+    // gma.conf shape `ingress.1.symbols = NEXO,VALT,...` consumed
+    // by IngressFactoryRegistry's market.wsclient.
+    std::string symbolsCsv;
+    if (row.HasMember("symbols") && row["symbols"].IsArray()) {
+      const auto& syms = row["symbols"];
+      for (rapidjson::SizeType s = 0; s < syms.Size(); ++s) {
+        if (!syms[s].IsString()) continue;
+        if (!symbolsCsv.empty()) symbolsCsv += ",";
+        symbolsCsv += syms[s].GetString();
+      }
+    }
+    if (symbolsCsv.empty()) {
+      symbolsCsv = "*";  // wildcard — same default as Config::FeedConfig
+    }
+
+    gma::util::Config::Ingress ing;
+    ing.kind = "market.wsclient";
+    ing.params["url"] = endpoint;
+    ing.params["adapter"] = protocol;  // "itch"
+    ing.params["symbols"] = symbolsCsv;
+    out.push_back(std::move(ing));
+
+    gma::util::logger().log(
+        gma::util::LogLevel::Info,
+        "forum.connectors.mapped",
+        {{"name", name}, {"endpoint", endpoint}, {"symbols", symbolsCsv}});
+  }
+
+  return out;
+}
+
+std::vector<gma::util::Config::Ingress>
+ConnectorsClient::fetchIngresses(const std::string& forumUrl,
+                                 const std::string& tenantId,
+                                 const std::string& bearer) {
+  ParsedURL url;
+  try {
+    url = parseUrl(forumUrl);
+  } catch (const std::exception& ex) {
+    throw std::runtime_error(std::string{"ConnectorsClient: bad URL: "} + ex.what());
+  }
+
+  std::string body = fetchWithRetry([&] {
+    if (url.tls) {
+#ifdef GMA_HAS_SSL
+      return fetchTls(url, tenantId, bearer);
+#else
+      throw std::runtime_error(
+          "ConnectorsClient: https forumUrl but binary built without GMA_HAS_SSL");
+#endif
+    }
+    return fetchPlain(url, tenantId, bearer);
+  });
+
+  auto ingresses = parseConnectorsJson(body);
+  gma::util::logger().log(
+      gma::util::LogLevel::Info,
+      "forum.connectors.fetched",
+      {{"count", std::to_string(ingresses.size())}, {"url", forumUrl}});
+  return ingresses;
+}
+
+} // namespace forum
+} // namespace gma

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -27,6 +27,9 @@
 // -------- Connectors --------
 #include "gma/market/MarketConnector.hpp"
 
+// -------- Forum-driven ingress --------
+#include "gma/forum/ConnectorsClient.hpp"
+
 // ---------------------------
 // Globals
 // ---------------------------
@@ -162,6 +165,44 @@ int main(int argc, char* argv[]) {
   // ENC-31: ensure cfg.ingress[] is populated even when the user provided
   // no INI (loadFromFile not called). Idempotent.
   cfg.synthesizeIngressFromLegacy();
+
+  // feed-sim-connector phase 2: when forumUrl is configured, replace
+  // cfg.ingress with what forum's /api/connectors says. Connector
+  // record is the source of truth; static INI ingress only matters
+  // for forum-less dev runs (which now go through this fallback).
+  // Env-var overrides apply when the INI didn't carry the keys.
+  {
+    auto envOr = [](const std::string& cfgVal, const char* envName) {
+      if (!cfgVal.empty()) return cfgVal;
+      const char* env = std::getenv(envName);
+      return env ? std::string{env} : std::string{};
+    };
+    const std::string forumUrl       = envOr(cfg.forumUrl,       "FORUM_URL");
+    const std::string forumTenantId  = envOr(cfg.forumTenantId,  "FORUM_TENANT_ID");
+    const std::string forumAuthToken = envOr(cfg.forumAuthToken, "FORUM_AGENT_TOKEN");
+
+    if (!forumUrl.empty()) {
+      try {
+        auto pulled = gma::forum::ConnectorsClient::fetchIngresses(
+            forumUrl, forumTenantId, forumAuthToken);
+        cfg.ingress = std::move(pulled);
+        logger().log(
+            LogLevel::Info,
+            "forum.connectors.ingress_replaced",
+            {{"count", std::to_string(cfg.ingress.size())}, {"forumUrl", forumUrl}});
+      } catch (const std::exception& ex) {
+        logger().log(
+            LogLevel::Error,
+            "forum.connectors.fetch_failed",
+            {{"err", ex.what()}, {"forumUrl", forumUrl}});
+        // Fail-fast per spec AC-6: do not boot with empty ingress
+        // and silently produce no data. The dev compose has forum
+        // as a depends_on; hitting this almost always means a
+        // misconfig the operator should see.
+        std::exit(1);
+      }
+    }
+  }
 
   // Replay any config keys parked during cfg.loadFromFile() through
   // ConfigNamespaceRegistry now that connectors have registered their

--- a/src/util/Config.cpp
+++ b/src/util/Config.cpp
@@ -152,6 +152,9 @@ bool Config::loadFromFile(const std::string& path) {
     else if (key == "metricsEnabled") { metricsEnabled = (val == "true" || val == "1" || val == "yes"); }
     else if (key == "metricsIntervalSec") { int v = std::atoi(val.c_str()); if (v > 0) metricsIntervalSec = v; }
     else if (key == "logLevel") { logLevel = val; }
+    else if (key == "forumUrl") { forumUrl = val; }
+    else if (key == "forumTenantId") { forumTenantId = val; }
+    else if (key == "forumAuthToken") { forumAuthToken = val; }
     else if (key == "feedUrl") { feedUrl = val; }
     else if (key == "feedSymbols") {
       feedSymbols.clear();

--- a/tests/forum/ConnectorsClientTest.cpp
+++ b/tests/forum/ConnectorsClientTest.cpp
@@ -1,0 +1,98 @@
+// Tests the JSON-to-ingress translation done by
+// gma::forum::ConnectorsClient::parseConnectorsJson. Decoupled from
+// the network — fed directly with the wire shape forum's
+// /api/connectors returns (cf.
+// forum/internal/http/routes/connectors.go ListConnectors), so any
+// drift in that endpoint surfaces here.
+
+#include "gma/forum/ConnectorsClient.hpp"
+
+#include <gtest/gtest.h>
+
+#include <stdexcept>
+#include <string>
+
+using gma::forum::ConnectorsClient;
+using Ingress = gma::util::Config::Ingress;
+
+namespace {
+
+const std::string kFeedSimRow = R"([{
+  "id": "84ca9d62-e0eb-5818-ab2f-d0fee8530e60",
+  "name": "feed-simulator",
+  "authMethod": "websocket",
+  "endpointUrl": "wss://feed-sim.v3m.xyz/feed",
+  "protocol": "itch",
+  "symbols": ["NEXO","VALT","RAYM","STRT","DRRB"],
+  "status": "connected",
+  "resources": [
+    {"name": "Equity Ticks", "fields": []}
+  ]
+}])";
+
+}  // namespace
+
+TEST(ConnectorsClientTest, MapsSingleFeedSimRow) {
+  auto ingresses = ConnectorsClient::parseConnectorsJson(kFeedSimRow);
+  ASSERT_EQ(ingresses.size(), 1u);
+  const auto& ing = ingresses[0];
+
+  EXPECT_EQ(ing.kind, "market.wsclient");
+
+  auto urlIt = ing.params.find("url");
+  ASSERT_NE(urlIt, ing.params.end());
+  EXPECT_EQ(urlIt->second, "wss://feed-sim.v3m.xyz/feed");
+
+  auto adapterIt = ing.params.find("adapter");
+  ASSERT_NE(adapterIt, ing.params.end());
+  EXPECT_EQ(adapterIt->second, "itch");
+
+  auto symbolsIt = ing.params.find("symbols");
+  ASSERT_NE(symbolsIt, ing.params.end());
+  EXPECT_EQ(symbolsIt->second, "NEXO,VALT,RAYM,STRT,DRRB");
+}
+
+TEST(ConnectorsClientTest, SkipsConnectorsWithUnknownProtocol) {
+  const std::string body = R"([
+    {"name": "feed-simulator", "endpointUrl": "wss://x/feed", "protocol": "itch", "symbols": ["A"]},
+    {"name": "binance", "endpointUrl": "wss://stream.binance.com/ws", "protocol": "binance-ws", "symbols": ["BTC"]}
+  ])";
+  auto ingresses = ConnectorsClient::parseConnectorsJson(body);
+  ASSERT_EQ(ingresses.size(), 1u);
+  EXPECT_EQ(ingresses[0].params.at("url"), "wss://x/feed");
+}
+
+TEST(ConnectorsClientTest, SkipsConnectorsWithEmptyEndpoint) {
+  const std::string body = R"([
+    {"name": "stub", "endpointUrl": "", "protocol": "itch", "symbols": ["A"]}
+  ])";
+  auto ingresses = ConnectorsClient::parseConnectorsJson(body);
+  EXPECT_EQ(ingresses.size(), 0u);
+}
+
+TEST(ConnectorsClientTest, EmptySymbolsArrayDefaultsToWildcard) {
+  const std::string body = R"([
+    {"name": "feed-simulator", "endpointUrl": "wss://x/feed", "protocol": "itch", "symbols": []}
+  ])";
+  auto ingresses = ConnectorsClient::parseConnectorsJson(body);
+  ASSERT_EQ(ingresses.size(), 1u);
+  EXPECT_EQ(ingresses[0].params.at("symbols"), "*");
+}
+
+TEST(ConnectorsClientTest, RejectsNonArrayPayload) {
+  // forum returns {"error":"..."} on auth failures; not a list — must throw.
+  EXPECT_THROW(
+      ConnectorsClient::parseConnectorsJson(R"({"error":"unauthorized"})"),
+      std::runtime_error);
+}
+
+TEST(ConnectorsClientTest, RejectsMalformedJson) {
+  EXPECT_THROW(
+      ConnectorsClient::parseConnectorsJson("not-json-at-all"),
+      std::runtime_error);
+}
+
+TEST(ConnectorsClientTest, EmptyArrayProducesNoIngresses) {
+  auto ingresses = ConnectorsClient::parseConnectorsJson("[]");
+  EXPECT_EQ(ingresses.size(), 0u);
+}


### PR DESCRIPTION
## Summary

Phase 2 of the [feed-sim-connector proposal](https://github.com/ndrandal/customer-layer/blob/main/specs/2026-05-07-feed-sim-connector/SPEC.md). gma_v3 stops reading its WS-client ingress from a static INI block and instead pulls connector rows from forum's REST API at startup, making the connector record the source of truth for what's subscribed.

- **New: `gma::forum::ConnectorsClient`** — synchronous one-shot HTTP/HTTPS GET against `/api/connectors`, parses JSON via RapidJSON, emits one `market.wsclient` Ingress per `protocol == "itch"` row.
- **`main.cpp` wiring** between `synthesizeIngressFromLegacy()` and `dispatchPendingKeys()`: when `cfg.forumUrl` (or env `FORUM_URL`) is non-empty, replaces `cfg.ingress` with the pulled list. Fail-fast on transport/parse error (per spec AC-6).
- **Config keys**: `forumUrl`, `forumTenantId`, `forumAuthToken` — all optional; INI or env-var. Empty → static INI ingress remains authoritative (legacy path, dev-without-forum).
- **Tests**: 7 new in `tests/forum/ConnectorsClientTest.cpp` covering the JSON-to-ingress mapping, skip rules, and error paths. Full suite still 420/421 (1 pre-existing skip).

Pairs with the sibling [gsd-workflow PR](pending) that retires `ingress.1.*` in `code/deploy/dev/gma-config/gma.conf` and adds `FORUM_URL` + `FORUM_AGENT_TOKEN` to the compose. Until that lands, this PR is a no-op at runtime (forumUrl is empty by default).

No Linear tickets — workspace is at the free-tier issue cap; tracking these as `no_ticket_yet:` in `customer-layer/specs/2026-05-07-feed-sim-connector/LINEAR.md` for backfill.

## Test plan

- [x] `ctest -R ConnectorsClientTest` — 7/7 pass
- [x] `gma_tests` full suite — 420/421 pass, 1 skipped (pre-existing `CorpusTestFixture.AllCorpusRequestsBuild`)
- [x] `cmake --build . -t gma_server` — clean link
- [ ] Reviewer: confirm Beast HTTP/HTTPS sync pattern is acceptable for a one-shot startup call
- [ ] Reviewer: gma.conf retires `ingress.1.*` only after this PR + the gsd-workflow PR land in lockstep