### PR TITLE
phase 1: gma_v3 accepts string IDs natively on WS subscribe

### DIFF
--- a/include/gma/nodes/Responder.hpp
+++ b/include/gma/nodes/Responder.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "gma/nodes/INode.hpp"
+#include "gma/server/RequestKey.hpp"
 #include "gma/StreamValue.hpp"
 #include <atomic>
 #include <functional>
@@ -9,12 +10,20 @@
 namespace gma::nodes {
 
 /// Sends each StreamValue back to the client via a callback.
+///
+/// The request key is a `gma::server::RequestKey` (variant<int,
+/// std::string>) so smoke.js's int-keyed wire and embassy's string-id
+/// wire are both supported. The callback is responsible for rendering
+/// the appropriate JSON field per variant alternative
+/// (`writeRequestKeyJSON` is the canonical helper).
 class Responder : public INode {
 public:
-    /// \param send  callback (key, StreamValue) -> void
+    using SendFn = std::function<void(const gma::server::RequestKey&,
+                                      const StreamValue&)>;
+
+    /// \param send  callback (RequestKey, StreamValue) -> void
     /// \param key   the request key to correlate responses
-    Responder(std::function<void(int,const StreamValue&)> send,
-              int key);
+    Responder(SendFn send, gma::server::RequestKey key);
 
     void onValue(const StreamValue& sv) override;
     void shutdown() noexcept override;
@@ -22,8 +31,8 @@ public:
 private:
     std::atomic<bool> stopped_{false};
     std::mutex mx_;
-    std::function<void(int,const StreamValue&)> send_;
-    int key_;
+    SendFn send_;
+    gma::server::RequestKey key_;
 };
 
 } // namespace gma::nodes

--- a/include/gma/server/ClientSession.hpp
+++ b/include/gma/server/ClientSession.hpp
@@ -17,6 +17,8 @@
 #include <string>
 #include <unordered_map>
 
+#include "gma/server/RequestKey.hpp"
+
 namespace gma {
 
 class WebSocketServer;
@@ -72,10 +74,11 @@ private:
   std::deque<std::string> outbox_;
   bool writing_{false};
 
-  // Active requests for this session.
+  // Active requests for this session. Variant key supports both
+  // smoke.js's int-keyed wire and embassy's string-id wire.
   std::mutex reqMu_;
-  std::unordered_map<int, std::shared_ptr<INode>> active_;
-  std::unordered_map<int, std::vector<std::shared_ptr<INode>>> chains_; // keeps pipeline alive
+  std::unordered_map<gma::server::RequestKey, std::shared_ptr<INode>> active_;
+  std::unordered_map<gma::server::RequestKey, std::vector<std::shared_ptr<INode>>> chains_; // keeps pipeline alive
 
   // Rate limiting: token-bucket for subscribe requests
   static constexpr int    RATE_LIMIT_BURST    = 20;   // max burst of subscribes

--- a/include/gma/server/RequestKey.hpp
+++ b/include/gma/server/RequestKey.hpp
@@ -1,0 +1,121 @@
+#pragma once
+
+// RequestKey — the per-subscription identifier carried on the WS
+// subscribe protocol and used to key ClientSession's active_/chains_
+// maps + the Responder's outbound rendering.
+//
+// Historically gma's WS surface was int-keyed: smoke.js (and any
+// int-native consumer) sends `{key: <int>, ...}`. Embassy and any
+// string-id-native consumer sends `{id: "<string>", ...}` (request IDs
+// from forum's saved-scene InstructionPackages look like
+// "r-NEXO-open"). This type holds either, with the variant index
+// tagging which alternative is in play.
+//
+// The variant lives at the wire boundary only — Dispatcher,
+// AtomicStore, TreeBuilder, and Listener stay key-type-agnostic
+// (they route on (streamKey, field), not on the request id).
+//
+// See gma_v3/specs/2026-05-08-gma-string-id-subscriptions/SPEC.md
+// and customer-layer/specs/2026-05-08-embassy-saved-scene-dispatch/
+// DECISIONS.md ADR-001 for the rationale.
+
+#include <functional>
+#include <optional>
+#include <string>
+#include <variant>
+
+#include <rapidjson/document.h>
+#include <rapidjson/stringbuffer.h>
+#include <rapidjson/writer.h>
+
+namespace gma {
+namespace server {
+
+using RequestKey = std::variant<int, std::string>;
+
+// Construct: explicit alternatives keep variant-construction unambiguous.
+inline RequestKey requestKeyInt(int v) { return RequestKey{std::in_place_index<0>, v}; }
+inline RequestKey requestKeyStr(std::string v) {
+  return RequestKey{std::in_place_index<1>, std::move(v)};
+}
+
+inline bool isInt(const RequestKey& k) { return k.index() == 0; }
+inline bool isStr(const RequestKey& k) { return k.index() == 1; }
+
+// writeRequestKeyJSON: emit the appropriate field+value pair on a
+// rapidjson Writer. Int subscriptions get `"key": <int>`; string
+// subscriptions get `"requestId": "<string>"`. The asymmetry is
+// deliberate — embassy's inboundProbe reads `requestId` (matching
+// the existing pattern across embassy's wire types); smoke.js reads
+// `key`. See SPEC.md "Outgoing JSON field naming for string-keyed
+// subs" — option (W).
+template <typename Writer>
+inline void writeRequestKeyJSON(Writer& w, const RequestKey& k) {
+  if (isInt(k)) {
+    w.Key("key");
+    w.Int(std::get<int>(k));
+  } else {
+    w.Key("requestId");
+    w.String(std::get<std::string>(k).c_str());
+  }
+}
+
+// parseRequestKeyFromObj: read either `key: <int>`, `id: <int>`
+// (legacy fallback), or `id: "<string>"` from a request object on the
+// subscribe wire. Returns std::nullopt if neither field is present
+// in a valid form. A request that supplies BOTH `key` AND `id` is
+// rejected — caller is expected to check this first (sendError).
+inline std::optional<RequestKey>
+parseRequestKeyFromObj(const rapidjson::Value& r) {
+  const bool hasKey = r.HasMember("key");
+  const bool hasId  = r.HasMember("id");
+
+  // Mutual exclusivity: both present is a protocol error. Caller
+  // reports it; we just signal "no valid key" here.
+  if (hasKey && hasId) return std::nullopt;
+
+  if (hasKey) {
+    if (!r["key"].IsInt()) return std::nullopt;
+    return requestKeyInt(r["key"].GetInt());
+  }
+  if (hasId) {
+    if (r["id"].IsInt()) return requestKeyInt(r["id"].GetInt());
+    if (r["id"].IsString()) return requestKeyStr(r["id"].GetString());
+  }
+  return std::nullopt;
+}
+
+// requestObjHasBothKeyAndId: caller-side helper for the
+// mutual-exclusivity check, because parseRequestKeyFromObj() returns
+// nullopt for "valid neither" and "both present" — distinguishing
+// the two is what the caller wants to error on.
+inline bool requestObjHasBothKeyAndId(const rapidjson::Value& r) {
+  return r.HasMember("key") && r.HasMember("id");
+}
+
+// keyDebugString: human-readable rendering for log lines. Int subs
+// get "key=N"; string subs get "requestId=..." (mirrors the wire
+// rendering so logs and frames line up).
+inline std::string keyDebugString(const RequestKey& k) {
+  if (isInt(k)) return "key=" + std::to_string(std::get<int>(k));
+  return "requestId=" + std::get<std::string>(k);
+}
+
+}  // namespace server
+}  // namespace gma
+
+// std::hash specialization so unordered_map<RequestKey, ...> works.
+// Salts on the variant index so int(5) and string("5") hash to
+// different buckets — catching the obvious silent-collision bug.
+namespace std {
+template <>
+struct hash<gma::server::RequestKey> {
+  std::size_t operator()(const gma::server::RequestKey& k) const noexcept {
+    const std::size_t idx = static_cast<std::size_t>(k.index());
+    if (idx == 0) {
+      return std::hash<int>{}(std::get<int>(k)) ^ (idx << 32);
+    }
+    return std::hash<std::string>{}(std::get<std::string>(k)) ^ ((idx + 1) << 32);
+  }
+};
+}  // namespace std

--- a/src/nodes/Responder.cpp
+++ b/src/nodes/Responder.cpp
@@ -3,10 +3,9 @@
 
 using namespace gma::nodes;
 
-Responder::Responder(std::function<void(int,const StreamValue&)> send,
-                     int key)
+Responder::Responder(SendFn send, gma::server::RequestKey key)
   : send_(std::move(send))
-  , key_(key)
+  , key_(std::move(key))
 {}
 
 void Responder::onValue(const StreamValue& sv) {
@@ -15,7 +14,7 @@ void Responder::onValue(const StreamValue& sv) {
     if (stopped_.load(std::memory_order_acquire)) return;
 
     // Copy send_ under lock to avoid TOCTOU race with shutdown().
-    std::function<void(int,const StreamValue&)> fn;
+    SendFn fn;
     {
         std::lock_guard<std::mutex> lk(mx_);
         fn = send_;

--- a/src/server/ClientSession.cpp
+++ b/src/server/ClientSession.cpp
@@ -347,14 +347,18 @@ void ClientSession::handleSubscribe(const ::rapidjson::Document& doc) {
       continue;
     }
 
-    // Request key (int)
-    int key = 0;
-    if (r.HasMember("key") && r["key"].IsInt()) key = r["key"].GetInt();
-    else if (r.HasMember("id") && r["id"].IsInt()) key = r["id"].GetInt();
-    else {
-      sendError("subscribe", "request missing integer 'key'");
+    // Request key — int (smoke.js / legacy clients) or string
+    // (embassy / saved-scene). See gma/server/RequestKey.hpp.
+    if (gma::server::requestObjHasBothKeyAndId(r)) {
+      sendError("subscribe", "request must have key (int) OR id (int|string), not both");
       continue;
     }
+    auto keyOpt = gma::server::parseRequestKeyFromObj(r);
+    if (!keyOpt) {
+      sendError("subscribe", "request missing valid 'key' (int) or 'id' (int|string)");
+      continue;
+    }
+    gma::server::RequestKey key = std::move(*keyOpt);
 
     if (!r.HasMember("streamKey") || !r["streamKey"].IsString()) {
       sendError("subscribe", "request missing 'streamKey' string");
@@ -386,7 +390,8 @@ void ClientSession::handleSubscribe(const ::rapidjson::Document& doc) {
     // Capture weak_ptr to avoid reference cycle:
     //   ClientSession → chains_ → Responder → sendFn → ClientSession
     auto weak = weak_from_this();
-    auto sendFn = [weak](int reqKey, const gma::StreamValue& sv) {
+    auto sendFn = [weak](const gma::server::RequestKey& reqKey,
+                         const gma::StreamValue& sv) {
       try {
         auto self = weak.lock();
         if (!self) return;
@@ -396,7 +401,7 @@ void ClientSession::handleSubscribe(const ::rapidjson::Document& doc) {
 
         w.StartObject();
         w.Key("type");   w.String("update");
-        w.Key("key");    w.Int(reqKey);
+        gma::server::writeRequestKeyJSON(w, reqKey);
         w.Key("streamKey"); w.String(sv.symbol.c_str());
         w.Key("value");  gma::util::writeArgTypeJson(w, sv.value);
         w.EndObject();
@@ -405,7 +410,8 @@ void ClientSession::handleSubscribe(const ::rapidjson::Document& doc) {
         self->sendText(sb.GetString());
       } catch (const std::exception& ex) {
         gma::util::logger().log(gma::util::LogLevel::Error,
-          "ws.sendFn exception", {{"err", ex.what()}, {"key", std::to_string(reqKey)}});
+          "ws.sendFn exception",
+          {{"err", ex.what()}, {"reqKey", gma::server::keyDebugString(reqKey)}});
       }
     };
 
@@ -494,16 +500,22 @@ void ClientSession::handleSubscribe(const ::rapidjson::Document& doc) {
       ::rapidjson::Writer<::rapidjson::StringBuffer> w(sb);
       w.StartObject();
       w.Key("type"); w.String("subscribed");
-      w.Key("key");  w.Int(key);
+      gma::server::writeRequestKeyJSON(w, key);
       w.EndObject();
 
       GMA_METRIC_HIT("ws.subscribe");
       GMA_METRIC_HIT("ws.msg_out");
       sendText(sb.GetString());
 
+      // Log structured field uses "key" or "requestId" mirroring the
+      // wire so operators grepping forum's instruction_id can hop
+      // straight into gma's view.
       gma::util::logger().log(gma::util::LogLevel::Info,
                               "ws.subscribe",
-                              { {"key", std::to_string(key)},
+                              { {gma::server::isInt(key) ? "key" : "requestId",
+                                 gma::server::isInt(key)
+                                     ? std::to_string(std::get<int>(key))
+                                     : std::get<std::string>(key)},
                                 {"streamKey", streamKey},
                                 {"field", field} });
     } catch (const std::exception& ex) {
@@ -513,19 +525,42 @@ void ClientSession::handleSubscribe(const ::rapidjson::Document& doc) {
 }
 
 void ClientSession::handleCancel(const ::rapidjson::Document& doc) {
-  if (!doc.HasMember("keys") || !doc["keys"].IsArray()) {
-    sendError("cancel", "missing 'keys' array");
+  // Accept legacy `keys: [int,...]` AND new `ids: ["...",...]` arrays.
+  // Both present in the same payload is a protocol error — keep the
+  // parser tight and the failure modes obvious.
+  const bool hasKeys = doc.HasMember("keys") && doc["keys"].IsArray();
+  const bool hasIds  = doc.HasMember("ids")  && doc["ids"].IsArray();
+
+  if (hasKeys && hasIds) {
+    sendError("cancel", "specify keys (int) or ids (string), not both");
+    return;
+  }
+  if (!hasKeys && !hasIds) {
+    sendError("cancel", "missing 'keys' (int array) or 'ids' (string array)");
     return;
   }
 
-  for (auto& v : doc["keys"].GetArray()) {
-    if (!v.IsInt()) {
-      sendError("cancel", "keys must be integers");
-      continue;
+  // Normalize to a vector<RequestKey>.
+  std::vector<gma::server::RequestKey> toCancel;
+  if (hasKeys) {
+    for (auto& v : doc["keys"].GetArray()) {
+      if (!v.IsInt()) {
+        sendError("cancel", "keys must be integers");
+        continue;
+      }
+      toCancel.push_back(gma::server::requestKeyInt(v.GetInt()));
     }
+  } else {  // hasIds
+    for (auto& v : doc["ids"].GetArray()) {
+      if (!v.IsString()) {
+        sendError("cancel", "ids must be strings");
+        continue;
+      }
+      toCancel.push_back(gma::server::requestKeyStr(v.GetString()));
+    }
+  }
 
-    const int key = v.GetInt();
-
+  for (auto& key : toCancel) {
     std::shared_ptr<gma::INode> root;
     {
       std::lock_guard<std::mutex> lk(reqMu_);
@@ -543,7 +578,7 @@ void ClientSession::handleCancel(const ::rapidjson::Document& doc) {
     ::rapidjson::Writer<::rapidjson::StringBuffer> w(sb);
     w.StartObject();
     w.Key("type"); w.String("canceled");
-    w.Key("key");  w.Int(key);
+    gma::server::writeRequestKeyJSON(w, key);
     w.EndObject();
 
     GMA_METRIC_HIT("ws.cancel");
@@ -552,7 +587,10 @@ void ClientSession::handleCancel(const ::rapidjson::Document& doc) {
 
     gma::util::logger().log(gma::util::LogLevel::Info,
                             "ws.cancel",
-                            { {"key", std::to_string(key)} });
+                            { {gma::server::isInt(key) ? "key" : "requestId",
+                               gma::server::isInt(key)
+                                   ? std::to_string(std::get<int>(key))
+                                   : std::get<std::string>(key)} });
   }
 }
 

--- a/tests/nodes/ResponderTest.cpp
+++ b/tests/nodes/ResponderTest.cpp
@@ -1,4 +1,5 @@
 #include "gma/nodes/Responder.hpp"
+#include "gma/server/RequestKey.hpp"
 #include "gma/StreamValue.hpp"
 #include <gtest/gtest.h>
 #include <stdexcept>
@@ -6,30 +7,35 @@
 
 using namespace gma;
 using namespace gma::nodes;
+using gma::server::RequestKey;
+using gma::server::requestKeyInt;
+using gma::server::requestKeyStr;
 
 TEST(ResponderTest, CallsCallbackWithCorrectKeyAndValue) {
-    int capturedKey = 0;
+    RequestKey capturedKey;
     StreamValue capturedSv;
-    auto callback = [&](int key, const StreamValue& sv) {
+    auto callback = [&](const RequestKey& key, const StreamValue& sv) {
         capturedKey = key;
         capturedSv = sv;
     };
-    Responder responder(callback, 42);
+    Responder responder(callback, requestKeyInt(42));
     StreamValue sv{"ABC", 3.14};
     responder.onValue(sv);
-    EXPECT_EQ(capturedKey, 42);
+    ASSERT_EQ(capturedKey.index(), 0u);
+    EXPECT_EQ(std::get<int>(capturedKey), 42);
     EXPECT_EQ(capturedSv.symbol, "ABC");
     EXPECT_DOUBLE_EQ(std::get<double>(capturedSv.value), 3.14);
 }
 
 TEST(ResponderTest, MultipleInvocations) {
     int count = 0;
-    auto callback = [&](int key, const StreamValue& sv) {
-        EXPECT_EQ(key, 7);
+    auto callback = [&](const RequestKey& key, const StreamValue& sv) {
+        ASSERT_EQ(key.index(), 0u);
+        EXPECT_EQ(std::get<int>(key), 7);
         EXPECT_EQ(sv.symbol, "X");
         ++count;
     };
-    Responder responder(callback, 7);
+    Responder responder(callback, requestKeyInt(7));
     for (int i = 0; i < 3; ++i) {
         responder.onValue({"X", 10});
     }
@@ -37,18 +43,18 @@ TEST(ResponderTest, MultipleInvocations) {
 }
 
 TEST(ResponderTest, ExceptionInCallbackIsCaught) {
-    auto callback = [&](int, const StreamValue&) {
+    auto callback = [&](const RequestKey&, const StreamValue&) {
         throw std::runtime_error("callback error");
     };
-    Responder responder(callback, 1);
+    Responder responder(callback, requestKeyInt(1));
     // onValue should catch exceptions and not propagate
     EXPECT_NO_THROW(responder.onValue({"S", 0}));
 }
 
 TEST(ResponderTest, ShutdownStopsSending) {
     int count = 0;
-    auto callback = [&](int, const StreamValue&) { ++count; };
-    Responder responder(callback, 100);
+    auto callback = [&](const RequestKey&, const StreamValue&) { ++count; };
+    Responder responder(callback, requestKeyInt(100));
     responder.onValue({"S", 5});
     EXPECT_EQ(count, 1);
     responder.shutdown();
@@ -58,7 +64,22 @@ TEST(ResponderTest, ShutdownStopsSending) {
 }
 
 TEST(ResponderTest, NullCallbackSafe) {
-    Responder responder(nullptr, 0);
+    Responder responder(nullptr, requestKeyInt(0));
     // Should not throw bad_function_call
     EXPECT_NO_THROW(responder.onValue({"S", 1}));
+}
+
+// Phase 1 of gma-string-id-subscriptions: the string-id path through
+// Responder. Callback receives a RequestKey whose alternative is the
+// std::string. Phase 2 adds round-trip integration tests through
+// ClientSession.
+TEST(ResponderTest, StringKeyIsThreadedThroughCallback) {
+    RequestKey capturedKey;
+    auto callback = [&](const RequestKey& key, const StreamValue&) {
+        capturedKey = key;
+    };
+    Responder responder(callback, requestKeyStr("r-NEXO-open"));
+    responder.onValue({"NEXO", 100.5});
+    ASSERT_EQ(capturedKey.index(), 1u);
+    EXPECT_EQ(std::get<std::string>(capturedKey), "r-NEXO-open");
 }


### PR DESCRIPTION
## Summary

Generalizes the GMA_V3 WS subscribe protocol so the request key is `variant<int, string>` rather than `int`. This is phase 1 of `gma-string-id-subscriptions` (proposal at `specs/2026-05-08-gma-string-id-subscriptions/`).

The wire change is the architecturally clean fix for embassy's silent-drop bug surfaced by the prior `embassy-saved-scene-dispatch` proposal — see ADR-001 in `customer-layer/specs/2026-05-08-embassy-saved-scene-dispatch/DECISIONS.md`. Embassy already sends `{id: "<string>", streamKey, field}`; gma's parser at `src/server/ClientSession.cpp:344-357` was rejecting it as "request missing integer 'key'" and silently dropping. Phase 1 makes the embassy-shaped subscribe a valid first-class input.

## What changed

- **NEW `include/gma/server/RequestKey.hpp`** — `using RequestKey = std::variant<int, std::string>` plus helpers (`requestKeyInt`, `requestKeyStr`, `parseRequestKeyFromObj`, `writeRequestKeyJSON`, `keyDebugString`, `requestObjHasBothKeyAndId`) and a `std::hash<RequestKey>` specialization with an index-salted hash so `int(N)` and `string("N")` never collide.
- **`Responder`** — ctor takes `RequestKey` (was `int`); `SendFn` widens to `const RequestKey&`.
- **`ClientSession::active_` / `chains_`** — now `unordered_map<RequestKey, ...>`. Subscribe parser accepts `{key:int}` ∣ `{id:int}` ∣ `{id:string}` (both-present is a protocol error). Cancel parser accepts `keys:[int,...]` AND `ids:[string,...]` (both-present per call is a protocol error).
- **Outbound frames** — value updates write either `"key":<int>` (int alt) or `"requestId":"<string>"` (string alt). Subscribe + cancel acks mirror the format. `ws.subscribe` / `ws.cancel` log lines branch on the alt for the field name.

The int-keyed protocol is untouched: `smoke.js` and any other legacy int-keyed client continues to work without changes.

## Phase 1 verification

- `cmake --build build -t gma_server -j4` clean
- `cmake --build build -t gma_tests -j4` clean
- `gma_tests` binary: **421 passing, 1 pre-existing skip** (`CorpusTestFixture.AllCorpusRequestsBuild`). New test added for the string-key path through `Responder`.
- `node tools/smoke-test/smoke.js --url ws://localhost:4001 --duration 30` against a fresh build paired with `feed-inject.js`: **PASS, 23/23 keys with data, 6391 updates**.

## Tickets

ENC-379 .. ENC-386 (phase 1 tasks 1-8). All transitioned to In Review on this push.

## Test plan

- [x] gma_tests passes locally (incl. new ResponderTest case)
- [x] smoke.js int-keyed regression: 23/23 keys with data
- [ ] Phase 2 will add an embassy-shaped string-id smoke (own ticket set ENC-387..392)