### PR TITLE
ENC-646: Tee multi-downstream fan-out node

### DIFF
--- a/include/gma/nodes/Tee.hpp
+++ b/include/gma/nodes/Tee.hpp
@@ -1,0 +1,45 @@
+// include/gma/nodes/Tee.hpp
+#pragma once
+#include <atomic>
+#include <cstddef>
+#include <memory>
+#include <mutex>
+#include <vector>
+#include "gma/nodes/INode.hpp"
+
+namespace gma {
+
+// Fan-out node: forwards each incoming StreamValue, unchanged, to every
+// downstream output. This is the data-plane multi-downstream primitive that
+// lets the request tree become a reuse DAG (let-bindings, ENC-647) and enables
+// value-conditioned routing (Switch, ENC-650).
+//
+// Contrast with CompositeRoot (src/core/TreeBuilder.cpp): that is a
+// lifecycle-only wrapper for independent source subtrees whose onValue() is a
+// no-op. Tee is a true data fan-out — onValue() pushes the value to N outputs.
+//
+// Ownership: a Tee exclusively owns its output subtrees and propagates
+// shutdown() to each (like CompositeRoot; unlike mid-pipeline Worker/Aggregate,
+// which only reset their single downstream). Every node's shutdown() is
+// idempotent, so double-shutdown via an external keepAlive list is safe.
+//
+// Thread-safety: mirrors Aggregate/Worker — a stopping_ flag plus a mutex
+// guarding the outputs vector; values are always forwarded outside the lock so
+// the mutex is never held during a downstream onValue().
+class Tee final : public INode {
+public:
+  explicit Tee(std::vector<std::shared_ptr<INode>> outputs);
+
+  void onValue(const StreamValue& sv) override;
+  void shutdown() noexcept override;
+
+  // Count of live outputs (test / introspection aid). Returns 0 after shutdown.
+  std::size_t size() const noexcept;
+
+private:
+  std::atomic<bool> stopping_{false};
+  mutable std::mutex mx_;
+  std::vector<std::shared_ptr<INode>> outputs_;
+};
+
+} // namespace gma

--- a/src/core/TreeBuilder.cpp
+++ b/src/core/TreeBuilder.cpp
@@ -17,6 +17,7 @@
 #include "gma/nodes/BucketTime.hpp"
 #include "gma/nodes/TumblingWindow.hpp"
 #include "gma/nodes/VectorReducer.hpp"
+#include "gma/nodes/Tee.hpp"
 
 // Runtime deps
 #include "gma/AtomicStore.hpp"
@@ -546,6 +547,30 @@ void registerBuiltinNodeTypes() {
                                  defaultStreamKey, deps, curDown);
       }
       return curDown;
+    });
+
+  // Tee fans each incoming value out to every output subtree, unchanged. Each
+  // entry of "outputs" is built as an independent subtree terminating in the
+  // shared `downstream`, so a Tee taps one upstream value into N parallel
+  // branches. The data-plane multi-downstream primitive underpinning
+  // let-bindings (ENC-647) and Switch (ENC-650).
+  NodeTypeRegistry::registerNodeType("Tee",
+    [](const rapidjson::Value& v, const std::string& defaultStreamKey,
+       const tree::Deps& deps, std::shared_ptr<INode> downstream)
+        -> std::shared_ptr<INode> {
+      if (!v.HasMember("outputs") || !v["outputs"].IsArray())
+        throw std::runtime_error("Tee: 'outputs' must be an array");
+
+      const auto& arr = v["outputs"];
+      if (arr.Size() == 0)
+        throw std::runtime_error("Tee: 'outputs' must not be empty");
+
+      std::vector<std::shared_ptr<INode>> outs;
+      outs.reserve(arr.Size());
+      for (auto& it : arr.GetArray())
+        outs.push_back(tree::buildOne(it, defaultStreamKey, deps, downstream));
+
+      return std::make_shared<Tee>(std::move(outs));
     });
 }
 

--- a/src/nodes/Tee.cpp
+++ b/src/nodes/Tee.cpp
@@ -1,0 +1,49 @@
+#include "gma/nodes/Tee.hpp"
+
+namespace gma {
+
+Tee::Tee(std::vector<std::shared_ptr<INode>> outputs)
+  : outputs_(std::move(outputs)) {}
+
+void Tee::onValue(const StreamValue& sv) {
+  // Early-out on stopping_ is an optimization; correctness is guaranteed by the
+  // mutex snapshot below: if shutdown() races, we observe an emptied vector.
+  if (stopping_.load(std::memory_order_acquire)) return;
+
+  // Snapshot the outputs under the lock, then forward outside it so the mutex
+  // is never held during a downstream onValue() (matches Aggregate/Worker).
+  std::vector<std::shared_ptr<INode>> outs;
+  {
+    std::lock_guard<std::mutex> lk(mx_);
+    outs = outputs_;
+  }
+
+  // Each output receives the same value, unchanged — this is the fan-out.
+  for (const auto& o : outs) {
+    if (o) o->onValue(sv);
+  }
+}
+
+void Tee::shutdown() noexcept {
+  stopping_.store(true, std::memory_order_release);
+
+  std::vector<std::shared_ptr<INode>> outs;
+  {
+    std::lock_guard<std::mutex> lk(mx_);
+    outs.swap(outputs_);
+  }
+
+  // Propagate to exclusively-owned outputs outside the lock. shutdown() is
+  // noexcept and idempotent on every node, so this is safe even when an
+  // external keepAlive list also shuts these nodes down.
+  for (auto& o : outs) {
+    if (o) o->shutdown();
+  }
+}
+
+std::size_t Tee::size() const noexcept {
+  std::lock_guard<std::mutex> lk(mx_);
+  return outputs_.size();
+}
+
+} // namespace gma

--- a/tests/nodes/TeeTest.cpp
+++ b/tests/nodes/TeeTest.cpp
@@ -1,0 +1,146 @@
+#include "gma/nodes/Tee.hpp"
+#include "gma/StreamValue.hpp"
+#include "gma/nodes/INode.hpp"
+#include <gtest/gtest.h>
+#include <atomic>
+#include <memory>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+using namespace gma;
+
+namespace {
+
+// Sink stub: records every received value and whether shutdown() was called.
+class TestSink : public INode {
+public:
+  std::mutex mx;
+  std::vector<StreamValue> received;
+  std::atomic<int> count{0};
+  std::atomic<bool> shutdownCalled{false};
+
+  void onValue(const StreamValue& sv) override {
+    std::lock_guard<std::mutex> lk(mx);
+    received.push_back(sv);
+    ++count;
+  }
+  void shutdown() noexcept override { shutdownCalled.store(true); }
+};
+
+double asDouble(const ArgType& a) { return std::get<double>(a); }
+
+std::shared_ptr<Tee> makeTee(std::vector<std::shared_ptr<TestSink>>& sinks,
+                             std::size_t n) {
+  std::vector<std::shared_ptr<INode>> outs;
+  for (std::size_t i = 0; i < n; ++i) {
+    auto s = std::make_shared<TestSink>();
+    sinks.push_back(s);
+    outs.push_back(s);
+  }
+  return std::make_shared<Tee>(std::move(outs));
+}
+
+} // namespace
+
+TEST(TeeTest, ForwardsOneValueToAllOutputs) {
+  std::vector<std::shared_ptr<TestSink>> sinks;
+  auto tee = makeTee(sinks, 3);
+
+  tee->onValue(StreamValue{"SYM", 42.0});
+
+  for (auto& s : sinks) {
+    ASSERT_EQ(s->count.load(), 1);
+    EXPECT_EQ(s->received[0].symbol, "SYM");
+    EXPECT_DOUBLE_EQ(asDouble(s->received[0].value), 42.0);
+  }
+}
+
+TEST(TeeTest, PreservesValueAndSymbolUnchanged) {
+  std::vector<std::shared_ptr<TestSink>> sinks;
+  auto tee = makeTee(sinks, 2);
+
+  tee->onValue(StreamValue{"AAPL", 1.5});
+  tee->onValue(StreamValue{"MSFT", -7.0});
+
+  for (auto& s : sinks) {
+    ASSERT_EQ(s->count.load(), 2);
+    EXPECT_EQ(s->received[0].symbol, "AAPL");
+    EXPECT_DOUBLE_EQ(asDouble(s->received[0].value), 1.5);
+    EXPECT_EQ(s->received[1].symbol, "MSFT");
+    EXPECT_DOUBLE_EQ(asDouble(s->received[1].value), -7.0);
+  }
+}
+
+TEST(TeeTest, ForwardsEveryValueInOrder) {
+  std::vector<std::shared_ptr<TestSink>> sinks;
+  auto tee = makeTee(sinks, 2);
+
+  std::vector<double> inputs{10.0, 20.0, 30.0, 40.0};
+  for (double v : inputs) tee->onValue(StreamValue{"X", v});
+
+  for (auto& s : sinks) {
+    ASSERT_EQ(s->count.load(), static_cast<int>(inputs.size()));
+    for (std::size_t i = 0; i < inputs.size(); ++i)
+      EXPECT_DOUBLE_EQ(asDouble(s->received[i].value), inputs[i]);
+  }
+}
+
+TEST(TeeTest, SingleOutputBehavesAsPassThrough) {
+  std::vector<std::shared_ptr<TestSink>> sinks;
+  auto tee = makeTee(sinks, 1);
+
+  tee->onValue(StreamValue{"S", 3.14});
+  ASSERT_EQ(sinks[0]->count.load(), 1);
+  EXPECT_DOUBLE_EQ(asDouble(sinks[0]->received[0].value), 3.14);
+}
+
+TEST(TeeTest, ShutdownPropagatesToAllOutputs) {
+  std::vector<std::shared_ptr<TestSink>> sinks;
+  auto tee = makeTee(sinks, 3);
+
+  EXPECT_EQ(tee->size(), 3u);
+  tee->shutdown();
+
+  for (auto& s : sinks) EXPECT_TRUE(s->shutdownCalled.load());
+  EXPECT_EQ(tee->size(), 0u);
+}
+
+TEST(TeeTest, DropsValuesAfterShutdown) {
+  std::vector<std::shared_ptr<TestSink>> sinks;
+  auto tee = makeTee(sinks, 2);
+
+  tee->onValue(StreamValue{"S", 1.0});
+  tee->shutdown();
+  tee->onValue(StreamValue{"S", 2.0}); // must be dropped
+
+  for (auto& s : sinks) EXPECT_EQ(s->count.load(), 1);
+}
+
+TEST(TeeTest, DoubleShutdownIsSafe) {
+  std::vector<std::shared_ptr<TestSink>> sinks;
+  auto tee = makeTee(sinks, 2);
+
+  tee->shutdown();
+  tee->shutdown(); // idempotent — must not crash or rethrow
+  for (auto& s : sinks) EXPECT_TRUE(s->shutdownCalled.load());
+}
+
+TEST(TeeTest, ConcurrentOnValueForwardsAll) {
+  std::vector<std::shared_ptr<TestSink>> sinks;
+  auto tee = makeTee(sinks, 2);
+
+  constexpr int kThreads = 4;
+  constexpr int kPerThread = 250;
+  std::vector<std::thread> ts;
+  for (int t = 0; t < kThreads; ++t) {
+    ts.emplace_back([&tee, t] {
+      for (int i = 0; i < kPerThread; ++i)
+        tee->onValue(StreamValue{"S", static_cast<double>(t * 1000 + i)});
+    });
+  }
+  for (auto& th : ts) th.join();
+
+  for (auto& s : sinks)
+    EXPECT_EQ(s->count.load(), kThreads * kPerThread);
+}

--- a/tests/treebuilder/TreeBuilderTest.cpp
+++ b/tests/treebuilder/TreeBuilderTest.cpp
@@ -68,6 +68,46 @@ TEST_F(TreeBuilderTestFixture, BuildForRequestRejectsMissingTree) {
     EXPECT_THROW(tree::buildForRequest(doc, deps, terminal), std::runtime_error);
 }
 
+// ----- Tee fan-out node (ENC-646) -----
+
+TEST_F(TreeBuilderTestFixture, BuildsTeeFanoutFromJson) {
+    initDeps();
+    auto terminal = std::make_shared<TerminalStub>();
+    rapidjson::Document doc;
+    doc.Parse(R"({
+      "type":"Tee",
+      "outputs":[
+        {"type":"Worker","fn":"last"},
+        {"type":"Worker","fn":"last"}
+      ]
+    })");
+    auto tee = tree::buildNode(doc, "SYM", deps, terminal);
+    ASSERT_TRUE(tee);
+
+    // One value into the Tee fans out through both Worker branches, each of
+    // which forwards into the shared terminal — so the terminal sees it twice.
+    tee->onValue(StreamValue{"SYM", 5.0});
+    EXPECT_EQ(terminal->received.size(), 2u);
+    for (const auto& sv : terminal->received)
+        EXPECT_DOUBLE_EQ(std::get<double>(sv.value), 5.0);
+}
+
+TEST_F(TreeBuilderTestFixture, TeeRejectsMissingOutputs) {
+    initDeps();
+    auto terminal = std::make_shared<TerminalStub>();
+    rapidjson::Document doc;
+    doc.Parse(R"({"type":"Tee"})");
+    EXPECT_THROW(tree::buildNode(doc, "SYM", deps, terminal), std::runtime_error);
+}
+
+TEST_F(TreeBuilderTestFixture, TeeRejectsEmptyOutputs) {
+    initDeps();
+    auto terminal = std::make_shared<TerminalStub>();
+    rapidjson::Document doc;
+    doc.Parse(R"({"type":"Tee","outputs":[]})");
+    EXPECT_THROW(tree::buildNode(doc, "SYM", deps, terminal), std::runtime_error);
+}
+
 TEST_F(TreeBuilderTestFixture, BuildForRequestBuildsListener) {
     initDeps();
     auto terminal = std::make_shared<TerminalStub>();


### PR DESCRIPTION
Part of the **GMA Expression Language Core** project (ENC-642…651). First structural ticket.

## What
Adds a `Tee` node that forwards each incoming `StreamValue`, unchanged, to N downstream outputs — the data-plane fan-out primitive the request tree needs to become a reuse DAG (let-bindings, ENC-647) and to do value-conditioned routing (Switch, ENC-650).

## Design
- Distinct from `CompositeRoot` (a lifecycle-only no-op wrapper for source subtrees); `Tee` is a true data fan-out.
- Owns its branch subtrees and propagates idempotent `shutdown()` (like `CompositeRoot`; unlike mid-pipeline `Worker`/`Aggregate`). Double-shutdown via the session `keepAlive` list is safe.
- Thread-safety mirrors `Aggregate`/`Worker`: `stopping_` flag + mutex-guarded outputs, values forwarded outside the lock.
- Registered as `{"type":"Tee","outputs":[<subtree>,...]}`; each output is an independent subtree terminating in the shared downstream.
- Bounded-cost-per-tick invariant preserved (fixed output count, no loops).

## Tests
8 node-level + 3 TreeBuilder integration. Full `gma_tests` suite green: **451 tests, 0 regressions**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)