### PR TITLE
ENC-642: keyed Record value type + JSON object (de)serialization

### DIFF
--- a/include/gma/StreamValue.hpp
+++ b/include/gma/StreamValue.hpp
@@ -1,15 +1,33 @@
 #pragma once
 
 #include <string>
+#include <type_traits>
+#include <utility>
 #include <variant>
 #include <vector>
 
 namespace gma {
 
-// Forward declare the wrapper struct first
+// Forward declarations first — ArgType, ArgValue, and RecordField form a
+// recursive cycle. The cycle is broken exactly the way the standard guarantees
+// for std::vector: a vector member may name an incomplete element type, so
+// Record can hold std::vector<RecordField> before RecordField is complete, and
+// ArgType's std::vector<ArgValue> can name ArgValue before it is complete.
 struct ArgValue;
+struct RecordField;
 
-// Define ArgType using ArgValue (not recursively itself)
+// Keyed record/map value (ENC-642): an insertion-ordered set of named fields —
+// the structured value type that lets one pipeline carry e.g. an OHLC candle
+// instead of N parallel scalar pipelines re-joined downstream. Records are
+// small by construction (a handful of fields), so lookup is linear. Insertion
+// order is preserved so serialization is deterministic and mirrors the order
+// the fields were packed.
+struct Record {
+  std::vector<RecordField> fields;
+};
+
+// ArgType: the value carried on every pipeline edge. `std::vector<ArgValue>` is
+// a positional (heterogeneous) array; `Record` is a keyed object.
 using ArgType = std::variant<
   bool,
   int,
@@ -17,10 +35,12 @@ using ArgType = std::variant<
   std::string,
   std::vector<int>,
   std::vector<double>,
-  std::vector<ArgValue>  
+  std::vector<ArgValue>,
+  Record
 >;
 
-// Define the wrapper struct
+// Wrapper that closes the recursion: an ArgValue *is* an ArgType, letting
+// arrays/records nest arbitrarily.
 struct ArgValue {
   ArgType value;
 
@@ -28,13 +48,38 @@ struct ArgValue {
   ArgValue(const ArgType& val) : value(val) {}
   ArgValue(ArgType&& val) : value(std::move(val)) {}
 
-  // Optional: enable implicit conversion from any ArgType alternative
+  // Enable implicit conversion from any ArgType alternative.
   template <typename T,
             typename = std::enable_if_t<!std::is_same_v<std::decay_t<T>, ArgValue>>>
   ArgValue(T&& val) : value(std::forward<T>(val)) {}
 };
 
-// Core value for computation — carries a stream-key + computed value through the node pipeline.
+// One named field of a Record. Defined after ArgValue so its ArgValue member is
+// complete here.
+struct RecordField {
+  std::string name;
+  ArgValue    value;
+};
+
+// ----- Record helpers (ArgValue/RecordField are complete from here on) -----
+
+// Returns a pointer to the named field's value, or nullptr if absent.
+inline const ArgType* recordFind(const Record& r, const std::string& key) {
+  for (const auto& f : r.fields)
+    if (f.name == key) return &f.value.value;
+  return nullptr;
+}
+
+// Inserts or overwrites a field. On overwrite the field keeps its original
+// position; new fields are appended (insertion order preserved).
+inline void recordSet(Record& r, const std::string& key, ArgType val) {
+  for (auto& f : r.fields)
+    if (f.name == key) { f.value.value = std::move(val); return; }
+  r.fields.push_back(RecordField{key, ArgValue{std::move(val)}});
+}
+
+// Core value for computation — carries a stream-key + computed value through the
+// node pipeline.
 struct StreamValue {
   std::string symbol;
   ArgType value;

--- a/include/gma/util/JsonUtil.hpp
+++ b/include/gma/util/JsonUtil.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <rapidjson/document.h>
 #include <rapidjson/writer.h>
 #include <rapidjson/stringbuffer.h>
 
@@ -46,11 +47,59 @@ inline void writeArgTypeJson(::rapidjson::Writer<::rapidjson::StringBuffer>& w,
       w.StartArray();
       for (const auto& it : x) writeArgValueJson(w, it);
       w.EndArray();
+    } else if constexpr (std::is_same_v<T, gma::Record>) {
+      // Keyed record -> JSON object, fields in insertion order (ENC-642).
+      w.StartObject();
+      for (const auto& f : x.fields) {
+        w.Key(f.name.c_str());
+        writeArgValueJson(w, f.value);
+      }
+      w.EndObject();
     } else {
       // Fallback: unknown variant alternative
       w.Null();
     }
   }, v);
+}
+
+// Serialize an ArgType to a JSON string (convenience for emit paths / tests).
+inline std::string toJsonString(const gma::ArgType& v) {
+  ::rapidjson::StringBuffer sb;
+  ::rapidjson::Writer<::rapidjson::StringBuffer> w(sb);
+  writeArgTypeJson(w, v);
+  return std::string(sb.GetString(), sb.GetSize());
+}
+
+// Inverse of writeArgTypeJson: build an ArgType from a parsed JSON value
+// (ENC-642). Objects become Records, arrays become positional ArgValue lists,
+// scalars map to bool/int/double/string. JSON null maps to a default value
+// (the structured types Pack/Field produce never contain nulls).
+inline gma::ArgType readArgTypeJson(const ::rapidjson::Value& v) {
+  if (v.IsBool())   return v.GetBool();
+  if (v.IsInt())    return v.GetInt();
+  if (v.IsNumber()) return v.GetDouble();
+  if (v.IsString()) return std::string(v.GetString(), v.GetStringLength());
+
+  if (v.IsArray()) {
+    std::vector<gma::ArgValue> out;
+    out.reserve(v.Size());
+    for (const auto& e : v.GetArray())
+      out.emplace_back(readArgTypeJson(e));
+    return out;
+  }
+
+  if (v.IsObject()) {
+    gma::Record r;
+    r.fields.reserve(v.MemberCount());
+    for (auto it = v.MemberBegin(); it != v.MemberEnd(); ++it)
+      r.fields.push_back(gma::RecordField{
+        std::string(it->name.GetString(), it->name.GetStringLength()),
+        gma::ArgValue{readArgTypeJson(it->value)}});
+    return r;
+  }
+
+  // null / unknown -> default (bool false).
+  return false;
 }
 
 } // namespace gma::util

--- a/tests/core/RecordValueTest.cpp
+++ b/tests/core/RecordValueTest.cpp
@@ -1,0 +1,104 @@
+#include "gma/StreamValue.hpp"
+#include "gma/util/JsonUtil.hpp"
+
+#include <gtest/gtest.h>
+#include <rapidjson/document.h>
+
+#include <string>
+#include <vector>
+
+using namespace gma;
+
+namespace {
+
+ArgType roundTrip(const std::string& json) {
+  rapidjson::Document d;
+  d.Parse(json.c_str());
+  EXPECT_FALSE(d.HasParseError());
+  return util::readArgTypeJson(d);
+}
+
+} // namespace
+
+TEST(RecordValueTest, SetGetAndAbsentField) {
+  Record r;
+  recordSet(r, "o", 1.5);
+  recordSet(r, "c", 2.5);
+
+  const ArgType* o = recordFind(r, "o");
+  ASSERT_NE(o, nullptr);
+  EXPECT_DOUBLE_EQ(std::get<double>(*o), 1.5);
+
+  const ArgType* c = recordFind(r, "c");
+  ASSERT_NE(c, nullptr);
+  EXPECT_DOUBLE_EQ(std::get<double>(*c), 2.5);
+
+  EXPECT_EQ(recordFind(r, "missing"), nullptr);
+}
+
+TEST(RecordValueTest, OverwriteKeepsPositionAndUpdatesValue) {
+  Record r;
+  recordSet(r, "a", 1.0);
+  recordSet(r, "b", 2.0);
+  recordSet(r, "a", 9.0); // overwrite — must stay first
+
+  ASSERT_EQ(r.fields.size(), 2u);
+  EXPECT_EQ(r.fields[0].name, "a");
+  EXPECT_DOUBLE_EQ(std::get<double>(r.fields[0].value.value), 9.0);
+  EXPECT_EQ(r.fields[1].name, "b");
+}
+
+TEST(RecordValueTest, SerializesToJsonObjectInInsertionOrder) {
+  Record r;
+  recordSet(r, "o", 1.5);
+  recordSet(r, "h", 3.5);
+  recordSet(r, "c", 2.5);
+
+  EXPECT_EQ(util::toJsonString(ArgType{r}),
+            R"({"o":1.5,"h":3.5,"c":2.5})");
+}
+
+TEST(RecordValueTest, NestedRecordSerializes) {
+  Record inner;
+  recordSet(inner, "b", 2.5);
+
+  Record outer;
+  recordSet(outer, "a", ArgType{inner});
+
+  EXPECT_EQ(util::toJsonString(ArgType{outer}),
+            R"({"a":{"b":2.5}})");
+}
+
+TEST(RecordValueTest, ReadBuildsRecordFromJsonObject) {
+  ArgType v = roundTrip(R"({"o":1.5,"c":2.5})");
+  ASSERT_TRUE(std::holds_alternative<Record>(v));
+  const Record& r = std::get<Record>(v);
+  ASSERT_EQ(r.fields.size(), 2u);
+  EXPECT_EQ(r.fields[0].name, "o");
+  EXPECT_DOUBLE_EQ(std::get<double>(r.fields[0].value.value), 1.5);
+}
+
+TEST(RecordValueTest, JsonRoundTripPreservesStructure) {
+  // Flat record of doubles.
+  const std::string flat = R"({"o":1.5,"h":3.5,"l":1.0,"c":2.5})";
+  EXPECT_EQ(util::toJsonString(roundTrip(flat)), flat);
+
+  // Nested object + heterogeneous array.
+  const std::string nested = R"({"a":{"b":2.5},"arr":[1.0,{"k":3.0}]})";
+  EXPECT_EQ(util::toJsonString(roundTrip(nested)), nested);
+
+  // Scalars and bool.
+  EXPECT_EQ(util::toJsonString(roundTrip(R"({"flag":true,"n":2.0})")),
+            R"({"flag":true,"n":2.0})");
+}
+
+TEST(RecordValueTest, RecordCarriedOnStreamValue) {
+  Record r;
+  recordSet(r, "price", 10.0);
+  StreamValue sv{"AAPL", ArgType{r}};
+
+  ASSERT_TRUE(std::holds_alternative<Record>(sv.value));
+  const ArgType* p = recordFind(std::get<Record>(sv.value), "price");
+  ASSERT_NE(p, nullptr);
+  EXPECT_DOUBLE_EQ(std::get<double>(*p), 10.0);
+}


### PR DESCRIPTION
Adds a keyed, insertion-ordered `Record` ArgType alternative + JSON object (de)serialization in JsonUtil; foundation for Pack/Field. Stacked on enc-646. 7 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)