### PR TITLE
ENC-645: Expr node (wire evaluator into the tree)

### DIFF
--- a/include/gma/Expr.hpp
+++ b/include/gma/Expr.hpp
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <functional>
+#include <set>
+#include <string>
+#include <unordered_map>
+
+#include <rapidjson/document.h>
+
+namespace gma::expr {
+
+// Evaluation environment: named input value -> double. The Expr node (ENC-645)
+// populates this from its wired inputs; absent names evaluate to 0.0.
+using Env = std::unordered_map<std::string, double>;
+
+// A compiled expression: a closure evaluated per tick over an Env. Compilation
+// happens once (at subscribe/build time); evaluation does no parsing and is
+// total and bounded — there are no loops, recursion, or unbounded work, so a
+// compiled Expr preserves the engine's bounded-cost-per-tick invariant.
+using Compiled = std::function<double(const Env&)>;
+
+// Compile a JSON expression tree into a Compiled closure. Grammar:
+//   number / bool           -> literal
+//   {"lit": <number|bool>}  -> literal
+//   {"ref": "<name>"}       -> named input reference (0.0 if absent at eval)
+//   {"op": "<operator>", "args": [<expr>, ...]}
+//   {"op": "fn", "name": "<builtin>", "args": [<expr>, ...]}  -> FunctionMap call
+//
+// Operators (numeric; comparisons/logical yield 1.0/0.0, truthy = value > 0.5):
+//   n-ary  : add mul min max and or
+//   binary : sub div mod gt lt gte lte eq neq
+//   unary  : neg abs not
+// div/mod by zero yield 0.0 (kept finite/total — no NaN/inf propagation).
+//
+// Throws std::runtime_error on any malformed expression (unknown op/fn, wrong
+// arity, bad node shape) so errors surface at build time, never at eval time.
+// If `refs` is non-null, every referenced input name is collected into it (so
+// a caller can discover which inputs an expression needs to be wired).
+Compiled compile(const rapidjson::Value& spec, std::set<std::string>* refs = nullptr);
+
+} // namespace gma::expr

--- a/include/gma/nodes/Expr.hpp
+++ b/include/gma/nodes/Expr.hpp
@@ -1,0 +1,34 @@
+// include/gma/nodes/Expr.hpp
+#pragma once
+#include <atomic>
+#include <memory>
+#include <mutex>
+#include "gma/nodes/INode.hpp"
+#include "gma/Expr.hpp"
+
+namespace gma {
+
+// Evaluates a compiled expression over each incoming value and forwards the
+// scalar result (ENC-645). The input exposes named refs to the expression:
+//   - a Record input  -> each field is a ref (by field name)
+//   - a scalar input  -> exposed under the ref name "value"
+//
+// Stateless and bounded: the expression is compiled once at build time and each
+// tick does O(expression size) work with no loops/recursion — the engine's
+// bounded-cost-per-tick invariant holds. Compose with Pack to assemble the
+// record of named inputs an expression reads: Pack -> Expr.
+class ExprNode final : public INode {
+public:
+  ExprNode(expr::Compiled fn, std::shared_ptr<INode> downstream);
+
+  void onValue(const StreamValue& sv) override;
+  void shutdown() noexcept override;
+
+private:
+  expr::Compiled fn_;
+  std::shared_ptr<INode> downstream_;
+  std::atomic<bool> stopping_{false};
+  mutable std::mutex mx_;
+};
+
+} // namespace gma

--- a/src/core/Expr.cpp
+++ b/src/core/Expr.cpp
@@ -1,0 +1,120 @@
+#include "gma/Expr.hpp"
+#include "gma/FunctionMap.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace gma::expr {
+namespace {
+
+Compiled compileNode(const rapidjson::Value& v, std::set<std::string>* refs);
+
+std::vector<Compiled> compileArgs(const rapidjson::Value& v,
+                                  std::set<std::string>* refs) {
+  if (!v.HasMember("args") || !v["args"].IsArray())
+    throw std::runtime_error("expr: operator requires an 'args' array");
+  std::vector<Compiled> out;
+  out.reserve(v["args"].Size());
+  for (const auto& a : v["args"].GetArray())
+    out.push_back(compileNode(a, refs));
+  return out;
+}
+
+Compiled compileNode(const rapidjson::Value& v, std::set<std::string>* refs) {
+  // Bare literals.
+  if (v.IsBool())   { double c = v.GetBool() ? 1.0 : 0.0; return [c](const Env&) { return c; }; }
+  if (v.IsNumber()) { double c = v.GetDouble();           return [c](const Env&) { return c; }; }
+  if (!v.IsObject())
+    throw std::runtime_error("expr: node must be a number, bool, or object");
+
+  // {"ref": "name"}
+  if (v.HasMember("ref")) {
+    if (!v["ref"].IsString())
+      throw std::runtime_error("expr: 'ref' must be a string");
+    std::string name = v["ref"].GetString();
+    if (refs) refs->insert(name);
+    return [name](const Env& e) {
+      auto it = e.find(name);
+      return it == e.end() ? 0.0 : it->second;  // absent input -> 0.0
+    };
+  }
+
+  // {"lit": <number|bool>}
+  if (v.HasMember("lit")) {
+    const auto& l = v["lit"];
+    if (l.IsBool())   { double c = l.GetBool() ? 1.0 : 0.0; return [c](const Env&) { return c; }; }
+    if (l.IsNumber()) { double c = l.GetDouble();           return [c](const Env&) { return c; }; }
+    throw std::runtime_error("expr: 'lit' must be a number or bool");
+  }
+
+  if (!v.HasMember("op") || !v["op"].IsString())
+    throw std::runtime_error("expr: object must have 'ref', 'lit', or 'op'");
+  const std::string op = v["op"].GetString();
+
+  // {"op":"fn","name":...} — bridge to the FunctionMap builtin registry.
+  if (op == "fn") {
+    if (!v.HasMember("name") || !v["name"].IsString())
+      throw std::runtime_error("expr: 'fn' requires a string 'name'");
+    const std::string fnName = v["name"].GetString();
+    gma::Func fn;
+    try {
+      fn = gma::FunctionMap::instance().getFunction(fnName);
+    } catch (...) {
+      throw std::runtime_error("expr: unknown fn '" + fnName + "'");
+    }
+    auto args = compileArgs(v, refs);
+    return [fn, args](const Env& e) {
+      std::vector<double> xs;
+      xs.reserve(args.size());
+      for (const auto& a : args) xs.push_back(a(e));
+      return fn(xs);
+    };
+  }
+
+  auto args = compileArgs(v, refs);
+  const auto needN = [&](std::size_t n) {
+    if (args.size() != n)
+      throw std::runtime_error("expr: '" + op + "' requires " + std::to_string(n) + " args");
+  };
+  const auto needAtLeast = [&](std::size_t n) {
+    if (args.size() < n)
+      throw std::runtime_error("expr: '" + op + "' requires at least " + std::to_string(n) + " args");
+  };
+
+  // --- n-ary ---
+  if (op == "add") { needAtLeast(1); return [args](const Env& e) { double s = 0.0; for (const auto& a : args) s += a(e); return s; }; }
+  if (op == "mul") { needAtLeast(1); return [args](const Env& e) { double s = 1.0; for (const auto& a : args) s *= a(e); return s; }; }
+  if (op == "min") { needAtLeast(1); return [args](const Env& e) { double s = args[0](e); for (std::size_t i = 1; i < args.size(); ++i) s = std::min(s, args[i](e)); return s; }; }
+  if (op == "max") { needAtLeast(1); return [args](const Env& e) { double s = args[0](e); for (std::size_t i = 1; i < args.size(); ++i) s = std::max(s, args[i](e)); return s; }; }
+  if (op == "and") { needAtLeast(1); return [args](const Env& e) { for (const auto& a : args) if (!(a(e) > 0.5)) return 0.0; return 1.0; }; }
+  if (op == "or")  { needAtLeast(1); return [args](const Env& e) { for (const auto& a : args) if (a(e) > 0.5) return 1.0; return 0.0; }; }
+
+  // --- binary ---
+  if (op == "sub") { needN(2); return [args](const Env& e) { return args[0](e) - args[1](e); }; }
+  if (op == "div") { needN(2); return [args](const Env& e) { double d = args[1](e); return d == 0.0 ? 0.0 : args[0](e) / d; }; }
+  if (op == "mod") { needN(2); return [args](const Env& e) { double d = args[1](e); return d == 0.0 ? 0.0 : std::fmod(args[0](e), d); }; }
+  if (op == "gt")  { needN(2); return [args](const Env& e) { return args[0](e) >  args[1](e) ? 1.0 : 0.0; }; }
+  if (op == "lt")  { needN(2); return [args](const Env& e) { return args[0](e) <  args[1](e) ? 1.0 : 0.0; }; }
+  if (op == "gte") { needN(2); return [args](const Env& e) { return args[0](e) >= args[1](e) ? 1.0 : 0.0; }; }
+  if (op == "lte") { needN(2); return [args](const Env& e) { return args[0](e) <= args[1](e) ? 1.0 : 0.0; }; }
+  if (op == "eq")  { needN(2); return [args](const Env& e) { return args[0](e) == args[1](e) ? 1.0 : 0.0; }; }
+  if (op == "neq") { needN(2); return [args](const Env& e) { return args[0](e) != args[1](e) ? 1.0 : 0.0; }; }
+
+  // --- unary ---
+  if (op == "neg") { needN(1); return [args](const Env& e) { return -args[0](e); }; }
+  if (op == "abs") { needN(1); return [args](const Env& e) { return std::fabs(args[0](e)); }; }
+  if (op == "not") { needN(1); return [args](const Env& e) { return args[0](e) > 0.5 ? 0.0 : 1.0; }; }
+
+  throw std::runtime_error("expr: unknown op '" + op + "'");
+}
+
+} // namespace
+
+Compiled compile(const rapidjson::Value& spec, std::set<std::string>* refs) {
+  return compileNode(spec, refs);
+}
+
+} // namespace gma::expr

--- a/src/core/TreeBuilder.cpp
+++ b/src/core/TreeBuilder.cpp
@@ -20,6 +20,7 @@
 #include "gma/nodes/Tee.hpp"
 #include "gma/nodes/Pack.hpp"
 #include "gma/nodes/Field.hpp"
+#include "gma/nodes/Expr.hpp"
 
 // Runtime deps
 #include "gma/AtomicStore.hpp"
@@ -621,6 +622,21 @@ void registerBuiltinNodeTypes() {
       if (name.empty())
         throw std::runtime_error("Field: missing 'name'");
       return std::make_shared<Field>(name, downstream);
+    });
+
+  // Expr evaluates a compiled expression over each incoming value. Shape:
+  // {"type":"Expr","expr":<expression-tree>}. A Record input exposes its fields
+  // as named refs; a scalar is exposed as ref "value". The expression is
+  // compiled once here (compile() throws on malformed input -> surfaces as a
+  // build error). Compose Pack -> Expr to read several named inputs.
+  NodeTypeRegistry::registerNodeType("Expr",
+    [](const rapidjson::Value& v, const std::string& /*defaultStreamKey*/,
+       const tree::Deps& /*deps*/, std::shared_ptr<INode> downstream)
+        -> std::shared_ptr<INode> {
+      if (!v.HasMember("expr"))
+        throw std::runtime_error("Expr: missing 'expr'");
+      auto fn = gma::expr::compile(v["expr"]);
+      return std::make_shared<ExprNode>(std::move(fn), downstream);
     });
 }
 

--- a/src/nodes/Expr.cpp
+++ b/src/nodes/Expr.cpp
@@ -1,0 +1,69 @@
+#include "gma/nodes/Expr.hpp"
+#include "gma/util/Logger.hpp"
+
+#include <exception>
+#include <type_traits>
+#include <variant>
+
+namespace gma {
+namespace {
+
+// File-local numeric coercion (mirrors TreeBuilder/TumblingWindow toDouble):
+// numbers map through; non-numeric values (strings, vectors, nested records)
+// collapse to 0.0 so an expression degrades gracefully.
+double toDouble(const ArgType& v) {
+  return std::visit([](auto&& x) -> double {
+    using T = std::decay_t<decltype(x)>;
+    if constexpr (std::is_same_v<T, bool>)        return x ? 1.0 : 0.0;
+    else if constexpr (std::is_same_v<T, int>)    return static_cast<double>(x);
+    else if constexpr (std::is_same_v<T, double>) return x;
+    else                                          return 0.0;
+  }, v);
+}
+
+} // namespace
+
+ExprNode::ExprNode(expr::Compiled fn, std::shared_ptr<INode> downstream)
+  : fn_(std::move(fn)), downstream_(std::move(downstream)) {}
+
+void ExprNode::onValue(const StreamValue& sv) {
+  if (stopping_.load(std::memory_order_acquire)) return;
+
+  std::shared_ptr<INode> ds;
+  {
+    std::lock_guard<std::mutex> lk(mx_);
+    ds = downstream_;
+  }
+  if (!ds) return;
+
+  // Build the evaluation environment from the input value.
+  expr::Env env;
+  if (const Record* r = std::get_if<Record>(&sv.value)) {
+    env.reserve(r->fields.size());
+    for (const auto& f : r->fields) env[f.name] = toDouble(f.value.value);
+  } else {
+    env.emplace("value", toDouble(sv.value));
+  }
+
+  double out;
+  try {
+    out = fn_(env);
+  } catch (const std::exception& ex) {
+    // A FunctionMap leaf (via {"op":"fn"}) threw — drop this tick rather than
+    // propagate, matching Worker's fn-exception discipline.
+    gma::util::logger().log(gma::util::LogLevel::Error,
+                            "expr.eval_exception",
+                            {{"symbol", sv.symbol}, {"err", ex.what()}});
+    return;
+  }
+
+  ds->onValue(StreamValue{sv.symbol, out});
+}
+
+void ExprNode::shutdown() noexcept {
+  stopping_.store(true, std::memory_order_release);
+  std::lock_guard<std::mutex> lk(mx_);
+  downstream_.reset();
+}
+
+} // namespace gma

--- a/tests/core/ExprTest.cpp
+++ b/tests/core/ExprTest.cpp
@@ -1,0 +1,125 @@
+#include "gma/Expr.hpp"
+
+#include <gtest/gtest.h>
+#include <rapidjson/document.h>
+
+#include <set>
+#include <string>
+
+using namespace gma;
+
+namespace {
+
+// compile() is eager — the returned closure captures literals/names/funcs by
+// value and retains no reference into the Document — so a local Document is safe.
+expr::Compiled compileJson(const std::string& json,
+                           std::set<std::string>* refs = nullptr) {
+  rapidjson::Document d;
+  d.Parse(json.c_str());
+  EXPECT_FALSE(d.HasParseError()) << json;
+  return expr::compile(d, refs);
+}
+
+double evalJson(const std::string& json, const expr::Env& env = {}) {
+  return compileJson(json)(env);
+}
+
+} // namespace
+
+TEST(ExprTest, Literals) {
+  EXPECT_DOUBLE_EQ(evalJson("3.5"), 3.5);
+  EXPECT_DOUBLE_EQ(evalJson("true"), 1.0);
+  EXPECT_DOUBLE_EQ(evalJson("false"), 0.0);
+  EXPECT_DOUBLE_EQ(evalJson(R"({"lit":7})"), 7.0);
+}
+
+TEST(ExprTest, RefPresentAndAbsent) {
+  EXPECT_DOUBLE_EQ(evalJson(R"({"ref":"x"})", {{"x", 42.0}}), 42.0);
+  EXPECT_DOUBLE_EQ(evalJson(R"({"ref":"missing"})", {{"x", 42.0}}), 0.0);
+}
+
+TEST(ExprTest, Arithmetic) {
+  EXPECT_DOUBLE_EQ(evalJson(R"({"op":"add","args":[1,2,3]})"), 6.0);
+  EXPECT_DOUBLE_EQ(evalJson(R"({"op":"sub","args":[10,4]})"), 6.0);
+  EXPECT_DOUBLE_EQ(evalJson(R"({"op":"mul","args":[2,3,4]})"), 24.0);
+  EXPECT_DOUBLE_EQ(evalJson(R"({"op":"div","args":[9,2]})"), 4.5);
+  EXPECT_DOUBLE_EQ(evalJson(R"({"op":"mod","args":[10,3]})"), 1.0);
+  EXPECT_DOUBLE_EQ(evalJson(R"({"op":"neg","args":[5]})"), -5.0);
+  EXPECT_DOUBLE_EQ(evalJson(R"({"op":"abs","args":[-5]})"), 5.0);
+  EXPECT_DOUBLE_EQ(evalJson(R"({"op":"min","args":[3,1,2]})"), 1.0);
+  EXPECT_DOUBLE_EQ(evalJson(R"({"op":"max","args":[3,1,2]})"), 3.0);
+}
+
+TEST(ExprTest, DivAndModByZeroAreFinite) {
+  EXPECT_DOUBLE_EQ(evalJson(R"({"op":"div","args":[1,0]})"), 0.0);
+  EXPECT_DOUBLE_EQ(evalJson(R"({"op":"mod","args":[1,0]})"), 0.0);
+}
+
+TEST(ExprTest, Comparisons) {
+  EXPECT_DOUBLE_EQ(evalJson(R"({"op":"gt","args":[2,1]})"), 1.0);
+  EXPECT_DOUBLE_EQ(evalJson(R"({"op":"gt","args":[1,2]})"), 0.0);
+  EXPECT_DOUBLE_EQ(evalJson(R"({"op":"lte","args":[2,2]})"), 1.0);
+  EXPECT_DOUBLE_EQ(evalJson(R"({"op":"eq","args":[3,3]})"), 1.0);
+  EXPECT_DOUBLE_EQ(evalJson(R"({"op":"neq","args":[3,4]})"), 1.0);
+}
+
+TEST(ExprTest, Logical) {
+  EXPECT_DOUBLE_EQ(evalJson(R"({"op":"and","args":[true,true]})"), 1.0);
+  EXPECT_DOUBLE_EQ(evalJson(R"({"op":"and","args":[true,false]})"), 0.0);
+  EXPECT_DOUBLE_EQ(evalJson(R"({"op":"or","args":[false,true]})"), 1.0);
+  EXPECT_DOUBLE_EQ(evalJson(R"({"op":"not","args":[false]})"), 1.0);
+}
+
+TEST(ExprTest, NestedComposition) {
+  // a*b + c  with a=2,b=3,c=4 -> 10
+  const char* json = R"({
+    "op":"add",
+    "args":[
+      {"op":"mul","args":[{"ref":"a"},{"ref":"b"}]},
+      {"ref":"c"}
+    ]
+  })";
+  EXPECT_DOUBLE_EQ(evalJson(json, {{"a", 2.0}, {"b", 3.0}, {"c", 4.0}}), 10.0);
+}
+
+TEST(ExprTest, RealWorldFormula) {
+  // (bid+ask)/2 - sma  with bid=10, ask=12, sma=9 -> 11 - 9 = 2
+  const char* json = R"({
+    "op":"sub",
+    "args":[
+      {"op":"div","args":[{"op":"add","args":[{"ref":"bid"},{"ref":"ask"}]},2]},
+      {"ref":"sma"}
+    ]
+  })";
+  EXPECT_DOUBLE_EQ(evalJson(json, {{"bid", 10.0}, {"ask", 12.0}, {"sma", 9.0}}), 2.0);
+}
+
+TEST(ExprTest, FnBridgeToFunctionMap) {
+  // FunctionMap builtins are installed by the global test bootstrap.
+  EXPECT_DOUBLE_EQ(evalJson(R"({"op":"fn","name":"sum","args":[1,2,3,4]})"), 10.0);
+  EXPECT_DOUBLE_EQ(evalJson(R"({"op":"fn","name":"mean","args":[2,4,6]})"), 4.0);
+}
+
+TEST(ExprTest, CollectsReferencedInputs) {
+  std::set<std::string> refs;
+  auto fn = compileJson(
+      R"({"op":"add","args":[{"ref":"bid"},{"op":"mul","args":[{"ref":"ask"},2]}]})",
+      &refs);
+  EXPECT_EQ(refs, (std::set<std::string>{"bid", "ask"}));
+  EXPECT_DOUBLE_EQ(fn({{"bid", 1.0}, {"ask", 3.0}}), 7.0);
+}
+
+TEST(ExprTest, MalformedExpressionsThrowAtCompileTime) {
+  auto compiles = [](const std::string& json) {
+    rapidjson::Document d;
+    d.Parse(json.c_str());
+    return expr::compile(d);
+  };
+  EXPECT_THROW(compiles(R"({"op":"bogus","args":[1]})"), std::runtime_error);
+  EXPECT_THROW(compiles(R"({"op":"fn","name":"nope","args":[1]})"), std::runtime_error);
+  EXPECT_THROW(compiles(R"({"op":"sub","args":[1]})"), std::runtime_error);        // bad arity
+  EXPECT_THROW(compiles(R"({"op":"add"})"), std::runtime_error);                   // no args
+  EXPECT_THROW(compiles(R"({"ref":5})"), std::runtime_error);                      // ref not string
+  EXPECT_THROW(compiles(R"("hello")"), std::runtime_error);                        // bare string
+  EXPECT_THROW(compiles(R"({"foo":1})"), std::runtime_error);                      // no ref/lit/op
+}

--- a/tests/nodes/ExprNodeTest.cpp
+++ b/tests/nodes/ExprNodeTest.cpp
@@ -1,0 +1,81 @@
+#include "gma/nodes/Expr.hpp"
+#include "gma/Expr.hpp"
+#include "gma/StreamValue.hpp"
+#include "gma/nodes/INode.hpp"
+#include <gtest/gtest.h>
+#include <memory>
+#include <rapidjson/document.h>
+#include <vector>
+
+using namespace gma;
+
+namespace {
+
+class Sink : public INode {
+public:
+  std::vector<StreamValue> received;
+  void onValue(const StreamValue& sv) override { received.push_back(sv); }
+  void shutdown() noexcept override {}
+};
+
+expr::Compiled compile(const char* json) {
+  rapidjson::Document d;
+  d.Parse(json);
+  EXPECT_FALSE(d.HasParseError());
+  return expr::compile(d);
+}
+
+ArgType recordOf(std::initializer_list<std::pair<const char*, double>> kvs) {
+  Record r;
+  for (auto& kv : kvs) recordSet(r, kv.first, kv.second);
+  return ArgType{r};
+}
+
+} // namespace
+
+TEST(ExprNodeTest, ScalarInputExposedAsValue) {
+  auto sink = std::make_shared<Sink>();
+  ExprNode n(compile(R"({"op":"mul","args":[{"ref":"value"},2]})"), sink);
+
+  n.onValue(StreamValue{"SYM", 5.0});
+  ASSERT_EQ(sink->received.size(), 1u);
+  EXPECT_EQ(sink->received[0].symbol, "SYM");
+  EXPECT_DOUBLE_EQ(std::get<double>(sink->received[0].value), 10.0);
+}
+
+TEST(ExprNodeTest, RecordFieldsExposedAsRefs) {
+  auto sink = std::make_shared<Sink>();
+  // (bid + ask) / 2
+  ExprNode n(compile(R"({"op":"div","args":[{"op":"add","args":[{"ref":"bid"},{"ref":"ask"}]},2]})"), sink);
+
+  n.onValue(StreamValue{"SYM", recordOf({{"bid", 10.0}, {"ask", 12.0}})});
+  ASSERT_EQ(sink->received.size(), 1u);
+  EXPECT_DOUBLE_EQ(std::get<double>(sink->received[0].value), 11.0);
+}
+
+TEST(ExprNodeTest, PredicateEmitsOneOrZero) {
+  auto sink = std::make_shared<Sink>();
+  ExprNode n(compile(R"({"op":"gt","args":[{"ref":"rsi"},70]})"), sink);
+
+  n.onValue(StreamValue{"S", recordOf({{"rsi", 80.0}})});
+  n.onValue(StreamValue{"S", recordOf({{"rsi", 60.0}})});
+  ASSERT_EQ(sink->received.size(), 2u);
+  EXPECT_DOUBLE_EQ(std::get<double>(sink->received[0].value), 1.0);
+  EXPECT_DOUBLE_EQ(std::get<double>(sink->received[1].value), 0.0);
+}
+
+TEST(ExprNodeTest, AbsentRefEvaluatesToZero) {
+  auto sink = std::make_shared<Sink>();
+  ExprNode n(compile(R"({"ref":"nope"})"), sink);
+  n.onValue(StreamValue{"S", recordOf({{"present", 1.0}})});
+  ASSERT_EQ(sink->received.size(), 1u);
+  EXPECT_DOUBLE_EQ(std::get<double>(sink->received[0].value), 0.0);
+}
+
+TEST(ExprNodeTest, DropsAfterShutdown) {
+  auto sink = std::make_shared<Sink>();
+  ExprNode n(compile(R"({"ref":"value"})"), sink);
+  n.shutdown();
+  n.onValue(StreamValue{"S", 1.0});
+  EXPECT_TRUE(sink->received.empty());
+}

--- a/tests/treebuilder/TreeBuilderTest.cpp
+++ b/tests/treebuilder/TreeBuilderTest.cpp
@@ -166,6 +166,37 @@ TEST_F(TreeBuilderTestFixture, PackRejectsEmptyFields) {
     EXPECT_THROW(tree::buildNode(doc, "SYM", deps, terminal), std::runtime_error);
 }
 
+// ----- Expr node (ENC-645) -----
+
+TEST_F(TreeBuilderTestFixture, BuildsExprFromJsonAndEvaluates) {
+    initDeps();
+    auto terminal = std::make_shared<TerminalStub>();
+    rapidjson::Document doc;
+    doc.Parse(R"({"type":"Expr","expr":{"op":"add","args":[{"ref":"value"},100]}})");
+    auto node = tree::buildNode(doc, "SYM", deps, terminal);
+    ASSERT_TRUE(node);
+
+    node->onValue(StreamValue{"SYM", 5.0});
+    ASSERT_EQ(terminal->received.size(), 1u);
+    EXPECT_DOUBLE_EQ(std::get<double>(terminal->received[0].value), 105.0);
+}
+
+TEST_F(TreeBuilderTestFixture, ExprRejectsMissingExpr) {
+    initDeps();
+    auto terminal = std::make_shared<TerminalStub>();
+    rapidjson::Document doc;
+    doc.Parse(R"({"type":"Expr"})");
+    EXPECT_THROW(tree::buildNode(doc, "SYM", deps, terminal), std::runtime_error);
+}
+
+TEST_F(TreeBuilderTestFixture, ExprRejectsMalformedExpr) {
+    initDeps();
+    auto terminal = std::make_shared<TerminalStub>();
+    rapidjson::Document doc;
+    doc.Parse(R"({"type":"Expr","expr":{"op":"bogus","args":[1]}})");
+    EXPECT_THROW(tree::buildNode(doc, "SYM", deps, terminal), std::runtime_error);
+}
+
 TEST_F(TreeBuilderTestFixture, BuildForRequestBuildsListener) {
     initDeps();
     auto terminal = std::make_shared<TerminalStub>();

--- a/tests/validation/ValidationTest.cpp
+++ b/tests/validation/ValidationTest.cpp
@@ -184,3 +184,28 @@ TEST(JsonValidatorRequireMemberTest, PassesOnCorrectType) {
     auto d = parseDoc("{\"foo\":42}");
     EXPECT_NO_THROW(JsonValidator::requireMember(d, "foo", kNumberType));
 }
+
+// --- Expr node payload (ENC-645): open-vocab walk accepts the expression
+//     tree (objects without "type"), and the depth cap bounds its size. ---
+
+TEST(JsonValidatorExprTest, AcceptsExprNodePayload) {
+    // The "expr" sub-tree's {op,args,ref,lit} objects carry no "type"; the
+    // open-vocabulary walk must accept them (they get depth/size checks only).
+    auto d = parseDoc(R"({
+      "type":"Expr",
+      "expr":{"op":"gt","args":[{"op":"add","args":[{"ref":"bid"},{"ref":"ask"}]},70]}
+    })");
+    EXPECT_NO_THROW(JsonValidator::validateTree(d));
+}
+
+TEST(JsonValidatorExprTest, RejectsOverDeepExpression) {
+    // A pathologically nested expression is bounded by MAX_TREE_DEPTH, keeping
+    // per-tick eval cost bounded (the total invariant).
+    std::string json = R"({"type":"Expr","expr":)";
+    for (int i = 0; i < 40; ++i) json += R"({"op":"neg","args":[)";
+    json += "1";
+    for (int i = 0; i < 40; ++i) json += "]}";
+    json += "}";
+    auto d = parseDoc(json);
+    EXPECT_THROW(JsonValidator::validateTree(d), std::runtime_error);
+}


### PR DESCRIPTION
Stateless Expr node evaluating over a Record (fields as refs) or scalar (as "value"); composes with Pack. Validator unchanged (open-vocab covers it). Stacked on enc-644. 10 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)