### PR TITLE
ENC-648: select/iff conditional function

### DIFF
--- a/src/core/BuiltinFunctions.cpp
+++ b/src/core/BuiltinFunctions.cpp
@@ -320,6 +320,20 @@ void registerBuiltinFunctions() {
         return (!v.empty() && v.back() <= 0.5) ? 1.0 : 0.0;
     });
 
+    // ──── Conditional (value-level branching) ────
+
+    // "select"/"iff": (cond, a, b) -> a if cond is truthy (>0.5) else b. The
+    // value-level branch — the cheapest control-flow primitive (ENC-648). Pure
+    // data, so it works anywhere a reducer does; most useful inside an Expr via
+    // {"op":"fn","name":"select","args":[<cond>,<a>,<b>]}. Fewer than 3 inputs
+    // yields 0.0.
+    auto selectFn = [](const std::vector<double>& v) -> double {
+        if (v.size() < 3) return 0.0;
+        return (v[0] > 0.5) ? v[1] : v[2];
+    };
+    fm.registerFunction("select", selectFn);
+    fm.registerFunction("iff", selectFn);
+
     // ──── Financial derivations ────
 
     fm.registerFunction("zscore", [](const std::vector<double>& v) -> double {

--- a/tests/core/SelectFunctionTest.cpp
+++ b/tests/core/SelectFunctionTest.cpp
@@ -1,0 +1,41 @@
+#include "gma/FunctionMap.hpp"
+#include "gma/Expr.hpp"
+
+#include <gtest/gtest.h>
+#include <rapidjson/document.h>
+
+using namespace gma;
+
+// FunctionMap builtins are installed by the global test bootstrap.
+
+TEST(SelectFunctionTest, SelectsByCondition) {
+  auto fn = FunctionMap::instance().getFunction("select");
+  EXPECT_DOUBLE_EQ(fn({1.0, 10.0, 20.0}), 10.0);  // cond truthy -> a
+  EXPECT_DOUBLE_EQ(fn({0.0, 10.0, 20.0}), 20.0);  // cond falsy  -> b
+  EXPECT_DOUBLE_EQ(fn({0.6, 10.0, 20.0}), 10.0);  // >0.5 is truthy
+  EXPECT_DOUBLE_EQ(fn({0.4, 10.0, 20.0}), 20.0);
+}
+
+TEST(SelectFunctionTest, TooFewInputsYieldsZero) {
+  auto fn = FunctionMap::instance().getFunction("select");
+  EXPECT_DOUBLE_EQ(fn({1.0}), 0.0);
+  EXPECT_DOUBLE_EQ(fn({1.0, 5.0}), 0.0);
+}
+
+TEST(SelectFunctionTest, IffIsAlias) {
+  auto fn = FunctionMap::instance().getFunction("iff");
+  EXPECT_DOUBLE_EQ(fn({1.0, 5.0, 9.0}), 5.0);
+  EXPECT_DOUBLE_EQ(fn({0.0, 5.0, 9.0}), 9.0);
+}
+
+TEST(SelectFunctionTest, UsableAsTernaryInsideExpr) {
+  // if rsi > 70 then 1 else 0
+  rapidjson::Document d;
+  d.Parse(R"({"op":"fn","name":"select","args":[
+    {"op":"gt","args":[{"ref":"rsi"},70]}, 1, 0
+  ]})");
+  ASSERT_FALSE(d.HasParseError());
+  auto fn = expr::compile(d);
+  EXPECT_DOUBLE_EQ(fn({{"rsi", 80.0}}), 1.0);
+  EXPECT_DOUBLE_EQ(fn({{"rsi", 60.0}}), 0.0);
+}


### PR DESCRIPTION
select(cond,a,b) FunctionMap builtin — value-level branch, usable as a ternary inside Expr. Stacked on enc-645. 4 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)