### PR TITLE
ENC-649: Filter predicate-gate node

### DIFF
--- a/include/gma/nodes/Filter.hpp
+++ b/include/gma/nodes/Filter.hpp
@@ -1,0 +1,33 @@
+// include/gma/nodes/Filter.hpp
+#pragma once
+#include <atomic>
+#include <memory>
+#include <mutex>
+#include "gma/nodes/INode.hpp"
+#include "gma/Expr.hpp"
+
+namespace gma {
+
+// Predicate gate (ENC-649): forwards each incoming value DOWNSTREAM UNCHANGED
+// when a compiled predicate expression over that value is truthy (>0.5), and
+// drops it otherwise. The predicate reads the value the same way Expr does — a
+// Record exposes its fields by name, a scalar is exposed as "value".
+//
+// INode::onValue stays void: Filter just conditionally calls downstream — the
+// node either forwards or doesn't, it never signals "suppress" up a return
+// path. Stateless and bounded (compiled once, O(predicate size) per tick).
+class Filter final : public INode {
+public:
+  Filter(expr::Compiled predicate, std::shared_ptr<INode> downstream);
+
+  void onValue(const StreamValue& sv) override;
+  void shutdown() noexcept override;
+
+private:
+  expr::Compiled pred_;
+  std::shared_ptr<INode> downstream_;
+  std::atomic<bool> stopping_{false};
+  mutable std::mutex mx_;
+};
+
+} // namespace gma

--- a/include/gma/nodes/NodeEnv.hpp
+++ b/include/gma/nodes/NodeEnv.hpp
@@ -1,0 +1,36 @@
+// include/gma/nodes/NodeEnv.hpp
+#pragma once
+#include <type_traits>
+#include <variant>
+#include "gma/StreamValue.hpp"
+#include "gma/Expr.hpp"
+
+namespace gma::nodes {
+
+// Numeric coercion shared by the expression-driven nodes (Expr, Filter,
+// Switch): numbers map through; non-numeric values (strings, vectors, nested
+// records) collapse to 0.0 so an expression degrades gracefully.
+inline double toDoubleArg(const ArgType& v) {
+  return std::visit([](auto&& x) -> double {
+    using T = std::decay_t<decltype(x)>;
+    if constexpr (std::is_same_v<T, bool>)        return x ? 1.0 : 0.0;
+    else if constexpr (std::is_same_v<T, int>)    return static_cast<double>(x);
+    else if constexpr (std::is_same_v<T, double>) return x;
+    else                                          return 0.0;
+  }, v);
+}
+
+// Build an expression evaluation Env from an incoming value: a Record exposes
+// each field by name; any scalar is exposed under the ref name "value".
+inline expr::Env envFromValue(const StreamValue& sv) {
+  expr::Env env;
+  if (const Record* r = std::get_if<Record>(&sv.value)) {
+    env.reserve(r->fields.size());
+    for (const auto& f : r->fields) env[f.name] = toDoubleArg(f.value.value);
+  } else {
+    env.emplace("value", toDoubleArg(sv.value));
+  }
+  return env;
+}
+
+} // namespace gma::nodes

--- a/src/core/BuiltinFunctions.cpp
+++ b/src/core/BuiltinFunctions.cpp
@@ -320,6 +320,20 @@ void registerBuiltinFunctions() {
         return (!v.empty() && v.back() <= 0.5) ? 1.0 : 0.0;
     });
 
+    // ──── Conditional (value-level branching) ────
+
+    // "select"/"iff": (cond, a, b) -> a if cond is truthy (>0.5) else b. The
+    // value-level branch — the cheapest control-flow primitive (ENC-648). Pure
+    // data, so it works anywhere a reducer does; most useful inside an Expr via
+    // {"op":"fn","name":"select","args":[<cond>,<a>,<b>]}. Fewer than 3 inputs
+    // yields 0.0.
+    auto selectFn = [](const std::vector<double>& v) -> double {
+        if (v.size() < 3) return 0.0;
+        return (v[0] > 0.5) ? v[1] : v[2];
+    };
+    fm.registerFunction("select", selectFn);
+    fm.registerFunction("iff", selectFn);
+
     // ──── Financial derivations ────
 
     fm.registerFunction("zscore", [](const std::vector<double>& v) -> double {

--- a/src/core/TreeBuilder.cpp
+++ b/src/core/TreeBuilder.cpp
@@ -21,6 +21,7 @@
 #include "gma/nodes/Pack.hpp"
 #include "gma/nodes/Field.hpp"
 #include "gma/nodes/Expr.hpp"
+#include "gma/nodes/Filter.hpp"
 
 // Runtime deps
 #include "gma/AtomicStore.hpp"
@@ -637,6 +638,19 @@ void registerBuiltinNodeTypes() {
         throw std::runtime_error("Expr: missing 'expr'");
       auto fn = gma::expr::compile(v["expr"]);
       return std::make_shared<ExprNode>(std::move(fn), downstream);
+    });
+
+  // Filter forwards each value unchanged iff a predicate expression over it is
+  // truthy. Shape: {"type":"Filter","when":<expression-tree>}. The predicate
+  // is compiled once (compile() throws on malformed -> build error).
+  NodeTypeRegistry::registerNodeType("Filter",
+    [](const rapidjson::Value& v, const std::string& /*defaultStreamKey*/,
+       const tree::Deps& /*deps*/, std::shared_ptr<INode> downstream)
+        -> std::shared_ptr<INode> {
+      if (!v.HasMember("when"))
+        throw std::runtime_error("Filter: missing 'when'");
+      auto pred = gma::expr::compile(v["when"]);
+      return std::make_shared<Filter>(std::move(pred), downstream);
     });
 }
 

--- a/src/nodes/Filter.cpp
+++ b/src/nodes/Filter.cpp
@@ -1,4 +1,4 @@
-#include "gma/nodes/Expr.hpp"
+#include "gma/nodes/Filter.hpp"
 #include "gma/nodes/NodeEnv.hpp"
 #include "gma/util/Logger.hpp"
 
@@ -6,10 +6,10 @@
 
 namespace gma {
 
-ExprNode::ExprNode(expr::Compiled fn, std::shared_ptr<INode> downstream)
-  : fn_(std::move(fn)), downstream_(std::move(downstream)) {}
+Filter::Filter(expr::Compiled predicate, std::shared_ptr<INode> downstream)
+  : pred_(std::move(predicate)), downstream_(std::move(downstream)) {}
 
-void ExprNode::onValue(const StreamValue& sv) {
+void Filter::onValue(const StreamValue& sv) {
   if (stopping_.load(std::memory_order_acquire)) return;
 
   std::shared_ptr<INode> ds;
@@ -19,24 +19,21 @@ void ExprNode::onValue(const StreamValue& sv) {
   }
   if (!ds) return;
 
-  expr::Env env = nodes::envFromValue(sv);
-
-  double out;
+  double verdict;
   try {
-    out = fn_(env);
+    verdict = pred_(nodes::envFromValue(sv));
   } catch (const std::exception& ex) {
-    // A FunctionMap leaf (via {"op":"fn"}) threw — drop this tick rather than
-    // propagate, matching Worker's fn-exception discipline.
     gma::util::logger().log(gma::util::LogLevel::Error,
-                            "expr.eval_exception",
+                            "filter.predicate_exception",
                             {{"symbol", sv.symbol}, {"err", ex.what()}});
-    return;
+    return;  // predicate threw -> drop (fail closed)
   }
 
-  ds->onValue(StreamValue{sv.symbol, out});
+  if (verdict > 0.5)
+    ds->onValue(sv);  // pass the original value through unchanged
 }
 
-void ExprNode::shutdown() noexcept {
+void Filter::shutdown() noexcept {
   stopping_.store(true, std::memory_order_release);
   std::lock_guard<std::mutex> lk(mx_);
   downstream_.reset();

--- a/tests/core/SelectFunctionTest.cpp
+++ b/tests/core/SelectFunctionTest.cpp
@@ -1,0 +1,41 @@
+#include "gma/FunctionMap.hpp"
+#include "gma/Expr.hpp"
+
+#include <gtest/gtest.h>
+#include <rapidjson/document.h>
+
+using namespace gma;
+
+// FunctionMap builtins are installed by the global test bootstrap.
+
+TEST(SelectFunctionTest, SelectsByCondition) {
+  auto fn = FunctionMap::instance().getFunction("select");
+  EXPECT_DOUBLE_EQ(fn({1.0, 10.0, 20.0}), 10.0);  // cond truthy -> a
+  EXPECT_DOUBLE_EQ(fn({0.0, 10.0, 20.0}), 20.0);  // cond falsy  -> b
+  EXPECT_DOUBLE_EQ(fn({0.6, 10.0, 20.0}), 10.0);  // >0.5 is truthy
+  EXPECT_DOUBLE_EQ(fn({0.4, 10.0, 20.0}), 20.0);
+}
+
+TEST(SelectFunctionTest, TooFewInputsYieldsZero) {
+  auto fn = FunctionMap::instance().getFunction("select");
+  EXPECT_DOUBLE_EQ(fn({1.0}), 0.0);
+  EXPECT_DOUBLE_EQ(fn({1.0, 5.0}), 0.0);
+}
+
+TEST(SelectFunctionTest, IffIsAlias) {
+  auto fn = FunctionMap::instance().getFunction("iff");
+  EXPECT_DOUBLE_EQ(fn({1.0, 5.0, 9.0}), 5.0);
+  EXPECT_DOUBLE_EQ(fn({0.0, 5.0, 9.0}), 9.0);
+}
+
+TEST(SelectFunctionTest, UsableAsTernaryInsideExpr) {
+  // if rsi > 70 then 1 else 0
+  rapidjson::Document d;
+  d.Parse(R"({"op":"fn","name":"select","args":[
+    {"op":"gt","args":[{"ref":"rsi"},70]}, 1, 0
+  ]})");
+  ASSERT_FALSE(d.HasParseError());
+  auto fn = expr::compile(d);
+  EXPECT_DOUBLE_EQ(fn({{"rsi", 80.0}}), 1.0);
+  EXPECT_DOUBLE_EQ(fn({{"rsi", 60.0}}), 0.0);
+}

--- a/tests/nodes/FilterTest.cpp
+++ b/tests/nodes/FilterTest.cpp
@@ -1,0 +1,74 @@
+#include "gma/nodes/Filter.hpp"
+#include "gma/Expr.hpp"
+#include "gma/StreamValue.hpp"
+#include "gma/nodes/INode.hpp"
+#include <gtest/gtest.h>
+#include <memory>
+#include <rapidjson/document.h>
+#include <vector>
+
+using namespace gma;
+
+namespace {
+
+class Sink : public INode {
+public:
+  std::vector<StreamValue> received;
+  void onValue(const StreamValue& sv) override { received.push_back(sv); }
+  void shutdown() noexcept override {}
+};
+
+expr::Compiled compile(const char* json) {
+  rapidjson::Document d;
+  d.Parse(json);
+  EXPECT_FALSE(d.HasParseError());
+  return expr::compile(d);
+}
+
+ArgType recordOf(std::initializer_list<std::pair<const char*, double>> kvs) {
+  Record r;
+  for (auto& kv : kvs) recordSet(r, kv.first, kv.second);
+  return ArgType{r};
+}
+
+} // namespace
+
+TEST(FilterTest, ForwardsWhenPredicateTrueDropsWhenFalse) {
+  auto sink = std::make_shared<Sink>();
+  Filter f(compile(R"({"op":"gt","args":[{"ref":"value"},0]})"), sink);
+
+  f.onValue(StreamValue{"S", 5.0});    // 5 > 0 -> pass
+  f.onValue(StreamValue{"S", -2.0});   // -2 > 0 -> drop
+  f.onValue(StreamValue{"S", 3.0});    // pass
+
+  ASSERT_EQ(sink->received.size(), 2u);
+  EXPECT_DOUBLE_EQ(std::get<double>(sink->received[0].value), 5.0);
+  EXPECT_DOUBLE_EQ(std::get<double>(sink->received[1].value), 3.0);
+}
+
+TEST(FilterTest, ForwardsValueUnchanged) {
+  auto sink = std::make_shared<Sink>();
+  // gate a record on rsi > 70, forwarding the whole record
+  Filter f(compile(R"({"op":"gt","args":[{"ref":"rsi"},70]})"), sink);
+
+  f.onValue(StreamValue{"S", recordOf({{"rsi", 80.0}, {"price", 12.0}})});
+  ASSERT_EQ(sink->received.size(), 1u);
+  ASSERT_TRUE(std::holds_alternative<Record>(sink->received[0].value));
+  const Record& r = std::get<Record>(sink->received[0].value);
+  EXPECT_DOUBLE_EQ(std::get<double>(*recordFind(r, "price")), 12.0);
+}
+
+TEST(FilterTest, RecordFailingPredicateIsDropped) {
+  auto sink = std::make_shared<Sink>();
+  Filter f(compile(R"({"op":"gt","args":[{"ref":"rsi"},70]})"), sink);
+  f.onValue(StreamValue{"S", recordOf({{"rsi", 50.0}})});
+  EXPECT_TRUE(sink->received.empty());
+}
+
+TEST(FilterTest, DropsAfterShutdown) {
+  auto sink = std::make_shared<Sink>();
+  Filter f(compile("true"), sink);  // always-pass predicate
+  f.shutdown();
+  f.onValue(StreamValue{"S", 1.0});
+  EXPECT_TRUE(sink->received.empty());
+}

--- a/tests/treebuilder/TreeBuilderTest.cpp
+++ b/tests/treebuilder/TreeBuilderTest.cpp
@@ -197,6 +197,30 @@ TEST_F(TreeBuilderTestFixture, ExprRejectsMalformedExpr) {
     EXPECT_THROW(tree::buildNode(doc, "SYM", deps, terminal), std::runtime_error);
 }
 
+// ----- Filter node (ENC-649) -----
+
+TEST_F(TreeBuilderTestFixture, BuildsFilterFromJsonAndGates) {
+    initDeps();
+    auto terminal = std::make_shared<TerminalStub>();
+    rapidjson::Document doc;
+    doc.Parse(R"({"type":"Filter","when":{"op":"gt","args":[{"ref":"value"},10]}})");
+    auto node = tree::buildNode(doc, "SYM", deps, terminal);
+    ASSERT_TRUE(node);
+
+    node->onValue(StreamValue{"SYM", 5.0});   // dropped
+    node->onValue(StreamValue{"SYM", 20.0});  // passed
+    ASSERT_EQ(terminal->received.size(), 1u);
+    EXPECT_DOUBLE_EQ(std::get<double>(terminal->received[0].value), 20.0);
+}
+
+TEST_F(TreeBuilderTestFixture, FilterRejectsMissingWhen) {
+    initDeps();
+    auto terminal = std::make_shared<TerminalStub>();
+    rapidjson::Document doc;
+    doc.Parse(R"({"type":"Filter"})");
+    EXPECT_THROW(tree::buildNode(doc, "SYM", deps, terminal), std::runtime_error);
+}
+
 TEST_F(TreeBuilderTestFixture, BuildForRequestBuildsListener) {
     initDeps();
     auto terminal = std::make_shared<TerminalStub>();


### PR DESCRIPTION
Forwards a value unchanged iff a predicate expression is truthy; extracts shared NodeEnv helper. Stacked on enc-648. 6 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)