### PR TITLE
ENC-650: Switch value-conditioned router

### DIFF
--- a/include/gma/nodes/Switch.hpp
+++ b/include/gma/nodes/Switch.hpp
@@ -1,0 +1,42 @@
+// include/gma/nodes/Switch.hpp
+#pragma once
+#include <atomic>
+#include <cstddef>
+#include <memory>
+#include <mutex>
+#include <vector>
+#include "gma/nodes/INode.hpp"
+#include "gma/Expr.hpp"
+
+namespace gma {
+
+// Value-conditioned router (ENC-650): evaluates a compiled selector expression
+// over each incoming value to pick an integer index, then forwards the value
+// UNCHANGED to exactly one of N case branches — true regime-switching (e.g. a
+// selector returning 0/1/2 for bear/flat/bull routes to three pipelines).
+//
+// The selector value is rounded to the nearest integer. In-range indices route
+// to cases[idx]; out-of-range routes to the optional default branch, or drops
+// if there is none. The complement of Tee (ENC-646): Tee broadcasts to all
+// outputs, Switch routes to one. Like Tee it exclusively owns its branches and
+// propagates idempotent shutdown(). Stateless, bounded (one branch per tick).
+class Switch final : public INode {
+public:
+  Switch(expr::Compiled selector,
+         std::vector<std::shared_ptr<INode>> cases,
+         std::shared_ptr<INode> defaultBranch);
+
+  void onValue(const StreamValue& sv) override;
+  void shutdown() noexcept override;
+
+  std::size_t caseCount() const noexcept;
+
+private:
+  expr::Compiled sel_;
+  std::vector<std::shared_ptr<INode>> cases_;
+  std::shared_ptr<INode> default_;  // may be null
+  std::atomic<bool> stopping_{false};
+  mutable std::mutex mx_;
+};
+
+} // namespace gma

--- a/src/core/TreeBuilder.cpp
+++ b/src/core/TreeBuilder.cpp
@@ -22,6 +22,7 @@
 #include "gma/nodes/Field.hpp"
 #include "gma/nodes/Expr.hpp"
 #include "gma/nodes/Filter.hpp"
+#include "gma/nodes/Switch.hpp"
 
 // Runtime deps
 #include "gma/AtomicStore.hpp"
@@ -651,6 +652,37 @@ void registerBuiltinNodeTypes() {
         throw std::runtime_error("Filter: missing 'when'");
       auto pred = gma::expr::compile(v["when"]);
       return std::make_shared<Filter>(std::move(pred), downstream);
+    });
+
+  // Switch routes each value to one of N case branches by a selector expression
+  // (rounded to an index); out-of-range routes to the optional default branch
+  // or drops. Shape: {"type":"Switch","select":<expr>,"cases":[<sub>,...],
+  // "default":<sub>?}. Each branch is built terminating in the shared
+  // `downstream`. The selector is compiled once (throws on malformed).
+  NodeTypeRegistry::registerNodeType("Switch",
+    [](const rapidjson::Value& v, const std::string& defaultStreamKey,
+       const tree::Deps& deps, std::shared_ptr<INode> downstream)
+        -> std::shared_ptr<INode> {
+      if (!v.HasMember("select"))
+        throw std::runtime_error("Switch: missing 'select'");
+      if (!v.HasMember("cases") || !v["cases"].IsArray())
+        throw std::runtime_error("Switch: 'cases' must be an array");
+      const auto& arr = v["cases"];
+      if (arr.Size() == 0)
+        throw std::runtime_error("Switch: 'cases' must not be empty");
+
+      auto sel = gma::expr::compile(v["select"]);
+
+      std::vector<std::shared_ptr<INode>> cases;
+      cases.reserve(arr.Size());
+      for (auto& it : arr.GetArray())
+        cases.push_back(tree::buildOne(it, defaultStreamKey, deps, downstream));
+
+      std::shared_ptr<INode> def;
+      if (v.HasMember("default"))
+        def = tree::buildOne(v["default"], defaultStreamKey, deps, downstream);
+
+      return std::make_shared<Switch>(std::move(sel), std::move(cases), std::move(def));
     });
 }
 

--- a/src/nodes/Switch.cpp
+++ b/src/nodes/Switch.cpp
@@ -1,0 +1,64 @@
+#include "gma/nodes/Switch.hpp"
+#include "gma/nodes/NodeEnv.hpp"
+#include "gma/util/Logger.hpp"
+
+#include <cmath>
+#include <exception>
+
+namespace gma {
+
+Switch::Switch(expr::Compiled selector,
+               std::vector<std::shared_ptr<INode>> cases,
+               std::shared_ptr<INode> defaultBranch)
+  : sel_(std::move(selector)),
+    cases_(std::move(cases)),
+    default_(std::move(defaultBranch)) {}
+
+void Switch::onValue(const StreamValue& sv) {
+  if (stopping_.load(std::memory_order_acquire)) return;
+
+  double s;
+  try {
+    s = sel_(nodes::envFromValue(sv));
+  } catch (const std::exception& ex) {
+    gma::util::logger().log(gma::util::LogLevel::Error,
+                            "switch.selector_exception",
+                            {{"symbol", sv.symbol}, {"err", ex.what()}});
+    return;  // selector threw -> drop
+  }
+
+  const long idx = std::lround(s);
+
+  std::shared_ptr<INode> branch;
+  {
+    std::lock_guard<std::mutex> lk(mx_);
+    if (idx >= 0 && static_cast<std::size_t>(idx) < cases_.size())
+      branch = cases_[static_cast<std::size_t>(idx)];
+    else
+      branch = default_;  // null if no default -> drop
+  }
+
+  if (branch) branch->onValue(sv);  // route the original value, unchanged
+}
+
+void Switch::shutdown() noexcept {
+  stopping_.store(true, std::memory_order_release);
+
+  std::vector<std::shared_ptr<INode>> branches;
+  std::shared_ptr<INode> def;
+  {
+    std::lock_guard<std::mutex> lk(mx_);
+    branches.swap(cases_);
+    def.swap(default_);
+  }
+  for (auto& b : branches)
+    if (b) b->shutdown();
+  if (def) def->shutdown();
+}
+
+std::size_t Switch::caseCount() const noexcept {
+  std::lock_guard<std::mutex> lk(mx_);
+  return cases_.size();
+}
+
+} // namespace gma

--- a/tests/nodes/SwitchTest.cpp
+++ b/tests/nodes/SwitchTest.cpp
@@ -1,0 +1,96 @@
+#include "gma/nodes/Switch.hpp"
+#include "gma/Expr.hpp"
+#include "gma/StreamValue.hpp"
+#include "gma/nodes/INode.hpp"
+#include <gtest/gtest.h>
+#include <memory>
+#include <rapidjson/document.h>
+#include <vector>
+
+using namespace gma;
+
+namespace {
+
+class Sink : public INode {
+public:
+  std::vector<StreamValue> received;
+  std::atomic<bool> shutdownCalled{false};
+  void onValue(const StreamValue& sv) override { received.push_back(sv); }
+  void shutdown() noexcept override { shutdownCalled.store(true); }
+};
+
+expr::Compiled compile(const char* json) {
+  rapidjson::Document d;
+  d.Parse(json);
+  EXPECT_FALSE(d.HasParseError());
+  return expr::compile(d);
+}
+
+} // namespace
+
+TEST(SwitchTest, RoutesBySelectorIndex) {
+  auto a = std::make_shared<Sink>();
+  auto b = std::make_shared<Sink>();
+  auto c = std::make_shared<Sink>();
+  // selector = the raw scalar value, rounded to an index
+  Switch sw(compile(R"({"ref":"value"})"),
+            {a, b, c}, /*default=*/nullptr);
+
+  sw.onValue(StreamValue{"S", 0.0});
+  sw.onValue(StreamValue{"S", 2.0});
+  sw.onValue(StreamValue{"S", 1.0});
+
+  ASSERT_EQ(a->received.size(), 1u);
+  ASSERT_EQ(b->received.size(), 1u);
+  ASSERT_EQ(c->received.size(), 1u);
+  EXPECT_DOUBLE_EQ(std::get<double>(a->received[0].value), 0.0);  // idx 0
+  EXPECT_DOUBLE_EQ(std::get<double>(b->received[0].value), 1.0);  // idx 1
+  EXPECT_DOUBLE_EQ(std::get<double>(c->received[0].value), 2.0);  // idx 2
+}
+
+TEST(SwitchTest, RoundsSelectorToNearestIndex) {
+  auto a = std::make_shared<Sink>();
+  auto b = std::make_shared<Sink>();
+  Switch sw(compile(R"({"ref":"value"})"), {a, b}, nullptr);
+
+  sw.onValue(StreamValue{"S", 0.4});  // -> 0
+  sw.onValue(StreamValue{"S", 0.6});  // -> 1
+  EXPECT_EQ(a->received.size(), 1u);
+  EXPECT_EQ(b->received.size(), 1u);
+}
+
+TEST(SwitchTest, OutOfRangeWithoutDefaultDrops) {
+  auto a = std::make_shared<Sink>();
+  Switch sw(compile(R"({"ref":"value"})"), {a}, nullptr);
+
+  sw.onValue(StreamValue{"S", 5.0});   // out of range
+  sw.onValue(StreamValue{"S", -1.0});  // negative
+  EXPECT_TRUE(a->received.empty());
+}
+
+TEST(SwitchTest, OutOfRangeRoutesToDefault) {
+  auto a = std::make_shared<Sink>();
+  auto def = std::make_shared<Sink>();
+  Switch sw(compile(R"({"ref":"value"})"), {a}, def);
+
+  sw.onValue(StreamValue{"S", 9.0});   // out of range -> default
+  ASSERT_EQ(def->received.size(), 1u);
+  EXPECT_DOUBLE_EQ(std::get<double>(def->received[0].value), 9.0);
+  EXPECT_TRUE(a->received.empty());
+}
+
+TEST(SwitchTest, ShutdownPropagatesToBranchesAndDefault) {
+  auto a = std::make_shared<Sink>();
+  auto b = std::make_shared<Sink>();
+  auto def = std::make_shared<Sink>();
+  Switch sw(compile(R"({"ref":"value"})"), {a, b}, def);
+
+  EXPECT_EQ(sw.caseCount(), 2u);
+  sw.shutdown();
+  EXPECT_TRUE(a->shutdownCalled.load());
+  EXPECT_TRUE(b->shutdownCalled.load());
+  EXPECT_TRUE(def->shutdownCalled.load());
+
+  sw.onValue(StreamValue{"S", 0.0});  // dropped after shutdown
+  EXPECT_TRUE(a->received.empty());
+}

--- a/tests/treebuilder/TreeBuilderTest.cpp
+++ b/tests/treebuilder/TreeBuilderTest.cpp
@@ -221,6 +221,43 @@ TEST_F(TreeBuilderTestFixture, FilterRejectsMissingWhen) {
     EXPECT_THROW(tree::buildNode(doc, "SYM", deps, terminal), std::runtime_error);
 }
 
+// ----- Switch node (ENC-650) -----
+
+TEST_F(TreeBuilderTestFixture, BuildsSwitchFromJsonAndRoutes) {
+    initDeps();
+    auto terminal = std::make_shared<TerminalStub>();
+    rapidjson::Document doc;
+    // select by value; two Worker(last) cases both forward into the terminal.
+    doc.Parse(R"({
+      "type":"Switch",
+      "select":{"ref":"value"},
+      "cases":[{"type":"Worker","fn":"last"},{"type":"Worker","fn":"last"}]
+    })");
+    auto node = tree::buildNode(doc, "SYM", deps, terminal);
+    ASSERT_TRUE(node);
+
+    node->onValue(StreamValue{"SYM", 1.0});  // routes to case 1 -> terminal
+    node->onValue(StreamValue{"SYM", 9.0});  // out of range, no default -> drop
+    ASSERT_EQ(terminal->received.size(), 1u);
+    EXPECT_DOUBLE_EQ(std::get<double>(terminal->received[0].value), 1.0);
+}
+
+TEST_F(TreeBuilderTestFixture, SwitchRejectsMissingSelect) {
+    initDeps();
+    auto terminal = std::make_shared<TerminalStub>();
+    rapidjson::Document doc;
+    doc.Parse(R"({"type":"Switch","cases":[{"type":"Worker","fn":"last"}]})");
+    EXPECT_THROW(tree::buildNode(doc, "SYM", deps, terminal), std::runtime_error);
+}
+
+TEST_F(TreeBuilderTestFixture, SwitchRejectsEmptyCases) {
+    initDeps();
+    auto terminal = std::make_shared<TerminalStub>();
+    rapidjson::Document doc;
+    doc.Parse(R"({"type":"Switch","select":{"ref":"value"},"cases":[]})");
+    EXPECT_THROW(tree::buildNode(doc, "SYM", deps, terminal), std::runtime_error);
+}
+
 TEST_F(TreeBuilderTestFixture, BuildForRequestBuildsListener) {
     initDeps();
     auto terminal = std::make_shared<TerminalStub>();


### PR DESCRIPTION
Routes a value to one of N case branches by a selector expression (+ optional default); the routing complement of Tee. Stacked on enc-649. 8 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)