### PR TITLE
ENC-647: let-bindings + Ref (reuse DAG)

### DIFF
--- a/include/gma/TreeBuilder.hpp
+++ b/include/gma/TreeBuilder.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <functional>
+#include <map>
 #include <memory>
 #include <string>
 #include <vector>
@@ -19,11 +20,28 @@ class Dispatcher;
 
 namespace tree {
 
+  // Build-time scope for let-bindings (ENC-647). A `Let` node installs a scope
+  // while building its body; each `Ref` resolves the binding name against the
+  // scope chain and registers its downstream as a consumer. After the body is
+  // built, the Let builds each referenced binding's producer once and fans it
+  // out (via Tee) to its consumers — turning the tree into a reuse DAG.
+  //
+  // Build-time only: producers and consumers are wired during buildOne and the
+  // scope is dead afterwards, so Ref is unsupported inside lazily-built
+  // subtrees (e.g. GroupSplit children).
+  struct BindingScope {
+    const rapidjson::Value* bindings { nullptr };   // the "bindings" object
+    BindingScope*           parent   { nullptr };   // enclosing scope, if any
+    // Referenced binding name -> the consumer nodes that should receive it.
+    std::map<std::string, std::vector<std::shared_ptr<INode>>> consumers;
+  };
+
   // Dependencies needed to build a tree
   struct Deps {
     AtomicStore*      store      { nullptr };   // for AtomicAccessor
     rt::ThreadPool*       pool       { nullptr };   // for Listener queues
     Dispatcher* dispatcher { nullptr };   // for Listener wiring
+    BindingScope*     bindingScope { nullptr }; // active let-binding scope (ENC-647)
   };
 
   // Result of buildForRequest – head plus the downstream chain.

--- a/include/gma/nodes/Switch.hpp
+++ b/include/gma/nodes/Switch.hpp
@@ -1,0 +1,42 @@
+// include/gma/nodes/Switch.hpp
+#pragma once
+#include <atomic>
+#include <cstddef>
+#include <memory>
+#include <mutex>
+#include <vector>
+#include "gma/nodes/INode.hpp"
+#include "gma/Expr.hpp"
+
+namespace gma {
+
+// Value-conditioned router (ENC-650): evaluates a compiled selector expression
+// over each incoming value to pick an integer index, then forwards the value
+// UNCHANGED to exactly one of N case branches — true regime-switching (e.g. a
+// selector returning 0/1/2 for bear/flat/bull routes to three pipelines).
+//
+// The selector value is rounded to the nearest integer. In-range indices route
+// to cases[idx]; out-of-range routes to the optional default branch, or drops
+// if there is none. The complement of Tee (ENC-646): Tee broadcasts to all
+// outputs, Switch routes to one. Like Tee it exclusively owns its branches and
+// propagates idempotent shutdown(). Stateless, bounded (one branch per tick).
+class Switch final : public INode {
+public:
+  Switch(expr::Compiled selector,
+         std::vector<std::shared_ptr<INode>> cases,
+         std::shared_ptr<INode> defaultBranch);
+
+  void onValue(const StreamValue& sv) override;
+  void shutdown() noexcept override;
+
+  std::size_t caseCount() const noexcept;
+
+private:
+  expr::Compiled sel_;
+  std::vector<std::shared_ptr<INode>> cases_;
+  std::shared_ptr<INode> default_;  // may be null
+  std::atomic<bool> stopping_{false};
+  mutable std::mutex mx_;
+};
+
+} // namespace gma

--- a/src/core/TreeBuilder.cpp
+++ b/src/core/TreeBuilder.cpp
@@ -100,6 +100,17 @@ private:
   std::vector<std::shared_ptr<gma::INode>> roots_;
 };
 
+// RefStub: the no-op head a `Ref` returns (ENC-647). A Ref has no local
+// upstream — its binding's producer feeds the Ref's downstream directly (via a
+// Tee) — so this stub never receives values. It exists only to satisfy the
+// builder contract (every buildOne returns an INode) and is kept alive by
+// whatever consumes the Ref position (e.g. an Aggregate's roots).
+class RefStub final : public gma::INode {
+public:
+  void onValue(const gma::StreamValue&) override {}
+  void shutdown() noexcept override {}
+};
+
 } // namespace
 
 //
@@ -683,6 +694,81 @@ void registerBuiltinNodeTypes() {
         def = tree::buildOne(v["default"], defaultStreamKey, deps, downstream);
 
       return std::make_shared<Switch>(std::move(sel), std::move(cases), std::move(def));
+    });
+
+  // Ref taps a named let-binding (ENC-647). It registers its downstream as a
+  // consumer of the binding in the active scope and returns a no-op stub — the
+  // binding's producer (built by the enclosing Let) fans its values into this
+  // downstream via a Tee. Errors if used outside a Let or naming an unknown
+  // binding.
+  NodeTypeRegistry::registerNodeType("Ref",
+    [](const rapidjson::Value& v, const std::string& /*defaultStreamKey*/,
+       const tree::Deps& deps, std::shared_ptr<INode> downstream)
+        -> std::shared_ptr<INode> {
+      const std::string name = strOr(v, "name", "");
+      if (name.empty())
+        throw std::runtime_error("Ref: missing 'name'");
+      if (!downstream)
+        throw std::runtime_error("Ref: '" + name + "' has no downstream consumer");
+
+      tree::BindingScope* s = deps.bindingScope;
+      while (s && !(s->bindings && s->bindings->HasMember(name.c_str())))
+        s = s->parent;
+      if (!s)
+        throw std::runtime_error("Ref: unknown binding '" + name + "'");
+
+      s->consumers[name].push_back(downstream);
+      return std::make_shared<RefStub>();
+    });
+
+  // Let defines named bindings reusable by Ref across its body, turning the
+  // tree into a reuse DAG. Shape: {"type":"Let","bindings":{name:<producer>},
+  // "body":<subtree-with-Refs>}. Two passes: (1) build the body under a fresh
+  // scope so Refs register their consumers; (2) for each referenced binding,
+  // build its producer ONCE feeding a Tee over its consumers (or the lone
+  // consumer directly). Unreferenced bindings are not built. Producers see the
+  // OUTER scope only, so sibling bindings can't reference each other — no
+  // cycles, preserving the bounded/total invariant.
+  NodeTypeRegistry::registerNodeType("Let",
+    [](const rapidjson::Value& v, const std::string& defaultStreamKey,
+       const tree::Deps& deps, std::shared_ptr<INode> downstream)
+        -> std::shared_ptr<INode> {
+      if (!v.HasMember("bindings") || !v["bindings"].IsObject())
+        throw std::runtime_error("Let: 'bindings' must be an object");
+      if (!v.HasMember("body") || !v["body"].IsObject())
+        throw std::runtime_error("Let: 'body' must be an object");
+
+      const auto& bindings = v["bindings"];
+
+      // Pass 1: build the body under a fresh scope; Refs register consumers.
+      tree::BindingScope scope;
+      scope.bindings = &bindings;
+      scope.parent   = deps.bindingScope;
+      tree::Deps bodyDeps = deps;
+      bodyDeps.bindingScope = &scope;
+      auto bodyHead = tree::buildOne(v["body"], defaultStreamKey, bodyDeps, downstream);
+
+      // Pass 2: build each referenced binding's producer once -> Tee/consumer.
+      std::vector<std::shared_ptr<INode>> roots;
+      for (auto& [name, consumers] : scope.consumers) {
+        if (consumers.empty()) continue;
+
+        std::shared_ptr<INode> sink;
+        if (consumers.size() == 1) {
+          sink = consumers.front();
+        } else {
+          auto tee = std::make_shared<Tee>(consumers);
+          roots.push_back(tee);  // own the Tee (a Listener producer holds it weakly)
+          sink = tee;
+        }
+
+        auto prodHead =
+          tree::buildOne(bindings[name.c_str()], defaultStreamKey, deps, sink);
+        roots.push_back(prodHead);
+      }
+
+      roots.push_back(bodyHead);
+      return std::make_shared<CompositeRoot>(std::move(roots));
     });
 }
 

--- a/src/core/TreeBuilder.cpp
+++ b/src/core/TreeBuilder.cpp
@@ -22,6 +22,7 @@
 #include "gma/nodes/Field.hpp"
 #include "gma/nodes/Expr.hpp"
 #include "gma/nodes/Filter.hpp"
+#include "gma/nodes/Switch.hpp"
 
 // Runtime deps
 #include "gma/AtomicStore.hpp"
@@ -651,6 +652,37 @@ void registerBuiltinNodeTypes() {
         throw std::runtime_error("Filter: missing 'when'");
       auto pred = gma::expr::compile(v["when"]);
       return std::make_shared<Filter>(std::move(pred), downstream);
+    });
+
+  // Switch routes each value to one of N case branches by a selector expression
+  // (rounded to an index); out-of-range routes to the optional default branch
+  // or drops. Shape: {"type":"Switch","select":<expr>,"cases":[<sub>,...],
+  // "default":<sub>?}. Each branch is built terminating in the shared
+  // `downstream`. The selector is compiled once (throws on malformed).
+  NodeTypeRegistry::registerNodeType("Switch",
+    [](const rapidjson::Value& v, const std::string& defaultStreamKey,
+       const tree::Deps& deps, std::shared_ptr<INode> downstream)
+        -> std::shared_ptr<INode> {
+      if (!v.HasMember("select"))
+        throw std::runtime_error("Switch: missing 'select'");
+      if (!v.HasMember("cases") || !v["cases"].IsArray())
+        throw std::runtime_error("Switch: 'cases' must be an array");
+      const auto& arr = v["cases"];
+      if (arr.Size() == 0)
+        throw std::runtime_error("Switch: 'cases' must not be empty");
+
+      auto sel = gma::expr::compile(v["select"]);
+
+      std::vector<std::shared_ptr<INode>> cases;
+      cases.reserve(arr.Size());
+      for (auto& it : arr.GetArray())
+        cases.push_back(tree::buildOne(it, defaultStreamKey, deps, downstream));
+
+      std::shared_ptr<INode> def;
+      if (v.HasMember("default"))
+        def = tree::buildOne(v["default"], defaultStreamKey, deps, downstream);
+
+      return std::make_shared<Switch>(std::move(sel), std::move(cases), std::move(def));
     });
 }
 

--- a/src/nodes/Switch.cpp
+++ b/src/nodes/Switch.cpp
@@ -1,0 +1,64 @@
+#include "gma/nodes/Switch.hpp"
+#include "gma/nodes/NodeEnv.hpp"
+#include "gma/util/Logger.hpp"
+
+#include <cmath>
+#include <exception>
+
+namespace gma {
+
+Switch::Switch(expr::Compiled selector,
+               std::vector<std::shared_ptr<INode>> cases,
+               std::shared_ptr<INode> defaultBranch)
+  : sel_(std::move(selector)),
+    cases_(std::move(cases)),
+    default_(std::move(defaultBranch)) {}
+
+void Switch::onValue(const StreamValue& sv) {
+  if (stopping_.load(std::memory_order_acquire)) return;
+
+  double s;
+  try {
+    s = sel_(nodes::envFromValue(sv));
+  } catch (const std::exception& ex) {
+    gma::util::logger().log(gma::util::LogLevel::Error,
+                            "switch.selector_exception",
+                            {{"symbol", sv.symbol}, {"err", ex.what()}});
+    return;  // selector threw -> drop
+  }
+
+  const long idx = std::lround(s);
+
+  std::shared_ptr<INode> branch;
+  {
+    std::lock_guard<std::mutex> lk(mx_);
+    if (idx >= 0 && static_cast<std::size_t>(idx) < cases_.size())
+      branch = cases_[static_cast<std::size_t>(idx)];
+    else
+      branch = default_;  // null if no default -> drop
+  }
+
+  if (branch) branch->onValue(sv);  // route the original value, unchanged
+}
+
+void Switch::shutdown() noexcept {
+  stopping_.store(true, std::memory_order_release);
+
+  std::vector<std::shared_ptr<INode>> branches;
+  std::shared_ptr<INode> def;
+  {
+    std::lock_guard<std::mutex> lk(mx_);
+    branches.swap(cases_);
+    def.swap(default_);
+  }
+  for (auto& b : branches)
+    if (b) b->shutdown();
+  if (def) def->shutdown();
+}
+
+std::size_t Switch::caseCount() const noexcept {
+  std::lock_guard<std::mutex> lk(mx_);
+  return cases_.size();
+}
+
+} // namespace gma

--- a/tests/integration/LetBindingsTest.cpp
+++ b/tests/integration/LetBindingsTest.cpp
@@ -1,0 +1,148 @@
+// End-to-end tests for let-bindings + Ref (ENC-647): a named binding's producer
+// is built ONCE and fanned (via Tee) to every Ref consumer — the reuse DAG.
+#include "gma/TreeBuilder.hpp"
+#include "gma/Dispatcher.hpp"
+#include "gma/AtomicStore.hpp"
+#include "gma/rt/ThreadPool.hpp"
+#include "gma/nodes/INode.hpp"
+
+#include <gtest/gtest.h>
+#include <rapidjson/document.h>
+
+#include <memory>
+#include <mutex>
+#include <vector>
+
+using namespace gma;
+
+namespace {
+
+class Terminal : public INode {
+public:
+  std::mutex mx;
+  std::vector<StreamValue> received;
+  void onValue(const StreamValue& sv) override {
+    std::lock_guard<std::mutex> lk(mx);
+    received.push_back(sv);
+  }
+  void shutdown() noexcept override {}
+  std::size_t size() {
+    std::lock_guard<std::mutex> lk(mx);
+    return received.size();
+  }
+};
+
+tree::Deps makeDeps(AtomicStore& store, rt::ThreadPool& pool, Dispatcher& d) {
+  tree::Deps deps;
+  deps.store = &store;
+  deps.pool = &pool;
+  deps.dispatcher = &d;
+  return deps;
+}
+
+} // namespace
+
+TEST(LetBindingsTest, BindingProducerBuiltOnceFansToTwoConsumers) {
+  rt::ThreadPool pool(1);
+  AtomicStore store;
+  Dispatcher dispatcher(&pool, &store);
+  auto deps = makeDeps(store, pool, dispatcher);
+  auto terminal = std::make_shared<Terminal>();
+
+  // mid is produced by one Listener; the body references it TWICE as the two
+  // inputs of an Aggregate(2). One source event must reach the Aggregate twice.
+  rapidjson::Document doc;
+  doc.Parse(R"({
+    "type":"Let",
+    "bindings":{ "mid":{"type":"Listener","streamKey":"SYM","field":"price"} },
+    "body":{
+      "type":"Aggregate","arity":2,
+      "inputs":[ {"type":"Ref","name":"mid"}, {"type":"Ref","name":"mid"} ]
+    }
+  })");
+  ASSERT_FALSE(doc.HasParseError());
+
+  auto root = tree::buildNode(doc, "SYM", deps, terminal);
+  ASSERT_TRUE(root);
+
+  dispatcher.notifyListeners("SYM", "price", 5.0);  // a single source event
+  pool.shutdown();                                   // drain
+
+  // The lone producer fanned its value to both Aggregate inputs, so the
+  // Aggregate(2) fired and emitted both values to the terminal.
+  ASSERT_EQ(terminal->size(), 2u);
+  EXPECT_DOUBLE_EQ(std::get<double>(terminal->received[0].value), 5.0);
+  EXPECT_DOUBLE_EQ(std::get<double>(terminal->received[1].value), 5.0);
+
+  root->shutdown();
+}
+
+TEST(LetBindingsTest, SingleConsumerBindingWorks) {
+  rt::ThreadPool pool(1);
+  AtomicStore store;
+  Dispatcher dispatcher(&pool, &store);
+  auto deps = makeDeps(store, pool, dispatcher);
+  auto terminal = std::make_shared<Terminal>();
+
+  rapidjson::Document doc;
+  doc.Parse(R"({
+    "type":"Let",
+    "bindings":{ "p":{"type":"Listener","streamKey":"SYM","field":"price"} },
+    "body":{ "type":"Ref","name":"p" }
+  })");
+  ASSERT_FALSE(doc.HasParseError());
+
+  auto root = tree::buildNode(doc, "SYM", deps, terminal);
+  ASSERT_TRUE(root);
+
+  dispatcher.notifyListeners("SYM", "price", 7.0);
+  pool.shutdown();
+
+  ASSERT_EQ(terminal->size(), 1u);
+  EXPECT_DOUBLE_EQ(std::get<double>(terminal->received[0].value), 7.0);
+  root->shutdown();
+}
+
+TEST(LetBindingsTest, RefToUnknownBindingThrows) {
+  rt::ThreadPool pool(1);
+  AtomicStore store;
+  Dispatcher dispatcher(&pool, &store);
+  auto deps = makeDeps(store, pool, dispatcher);
+  auto terminal = std::make_shared<Terminal>();
+
+  rapidjson::Document doc;
+  doc.Parse(R"({
+    "type":"Let",
+    "bindings":{ "x":{"type":"Listener","streamKey":"SYM","field":"price"} },
+    "body":{ "type":"Ref","name":"nope" }
+  })");
+  EXPECT_THROW(tree::buildNode(doc, "SYM", deps, terminal), std::runtime_error);
+}
+
+TEST(LetBindingsTest, RefOutsideLetThrows) {
+  rt::ThreadPool pool(1);
+  AtomicStore store;
+  Dispatcher dispatcher(&pool, &store);
+  auto deps = makeDeps(store, pool, dispatcher);
+  auto terminal = std::make_shared<Terminal>();
+
+  rapidjson::Document doc;
+  doc.Parse(R"({"type":"Ref","name":"x"})");
+  EXPECT_THROW(tree::buildNode(doc, "SYM", deps, terminal), std::runtime_error);
+}
+
+TEST(LetBindingsTest, RejectsMissingBindingsOrBody) {
+  rt::ThreadPool pool(1);
+  AtomicStore store;
+  Dispatcher dispatcher(&pool, &store);
+  auto deps = makeDeps(store, pool, dispatcher);
+  auto terminal = std::make_shared<Terminal>();
+
+  rapidjson::Document a;
+  a.Parse(R"({"type":"Let","body":{"type":"Worker","fn":"last"}})");
+  EXPECT_THROW(tree::buildNode(a, "SYM", deps, terminal), std::runtime_error);
+
+  rapidjson::Document b;
+  b.Parse(R"({"type":"Let","bindings":{"x":{"type":"Worker","fn":"last"}}})");
+  EXPECT_THROW(tree::buildNode(b, "SYM", deps, terminal), std::runtime_error);
+}

--- a/tests/nodes/SwitchTest.cpp
+++ b/tests/nodes/SwitchTest.cpp
@@ -1,0 +1,96 @@
+#include "gma/nodes/Switch.hpp"
+#include "gma/Expr.hpp"
+#include "gma/StreamValue.hpp"
+#include "gma/nodes/INode.hpp"
+#include <gtest/gtest.h>
+#include <memory>
+#include <rapidjson/document.h>
+#include <vector>
+
+using namespace gma;
+
+namespace {
+
+class Sink : public INode {
+public:
+  std::vector<StreamValue> received;
+  std::atomic<bool> shutdownCalled{false};
+  void onValue(const StreamValue& sv) override { received.push_back(sv); }
+  void shutdown() noexcept override { shutdownCalled.store(true); }
+};
+
+expr::Compiled compile(const char* json) {
+  rapidjson::Document d;
+  d.Parse(json);
+  EXPECT_FALSE(d.HasParseError());
+  return expr::compile(d);
+}
+
+} // namespace
+
+TEST(SwitchTest, RoutesBySelectorIndex) {
+  auto a = std::make_shared<Sink>();
+  auto b = std::make_shared<Sink>();
+  auto c = std::make_shared<Sink>();
+  // selector = the raw scalar value, rounded to an index
+  Switch sw(compile(R"({"ref":"value"})"),
+            {a, b, c}, /*default=*/nullptr);
+
+  sw.onValue(StreamValue{"S", 0.0});
+  sw.onValue(StreamValue{"S", 2.0});
+  sw.onValue(StreamValue{"S", 1.0});
+
+  ASSERT_EQ(a->received.size(), 1u);
+  ASSERT_EQ(b->received.size(), 1u);
+  ASSERT_EQ(c->received.size(), 1u);
+  EXPECT_DOUBLE_EQ(std::get<double>(a->received[0].value), 0.0);  // idx 0
+  EXPECT_DOUBLE_EQ(std::get<double>(b->received[0].value), 1.0);  // idx 1
+  EXPECT_DOUBLE_EQ(std::get<double>(c->received[0].value), 2.0);  // idx 2
+}
+
+TEST(SwitchTest, RoundsSelectorToNearestIndex) {
+  auto a = std::make_shared<Sink>();
+  auto b = std::make_shared<Sink>();
+  Switch sw(compile(R"({"ref":"value"})"), {a, b}, nullptr);
+
+  sw.onValue(StreamValue{"S", 0.4});  // -> 0
+  sw.onValue(StreamValue{"S", 0.6});  // -> 1
+  EXPECT_EQ(a->received.size(), 1u);
+  EXPECT_EQ(b->received.size(), 1u);
+}
+
+TEST(SwitchTest, OutOfRangeWithoutDefaultDrops) {
+  auto a = std::make_shared<Sink>();
+  Switch sw(compile(R"({"ref":"value"})"), {a}, nullptr);
+
+  sw.onValue(StreamValue{"S", 5.0});   // out of range
+  sw.onValue(StreamValue{"S", -1.0});  // negative
+  EXPECT_TRUE(a->received.empty());
+}
+
+TEST(SwitchTest, OutOfRangeRoutesToDefault) {
+  auto a = std::make_shared<Sink>();
+  auto def = std::make_shared<Sink>();
+  Switch sw(compile(R"({"ref":"value"})"), {a}, def);
+
+  sw.onValue(StreamValue{"S", 9.0});   // out of range -> default
+  ASSERT_EQ(def->received.size(), 1u);
+  EXPECT_DOUBLE_EQ(std::get<double>(def->received[0].value), 9.0);
+  EXPECT_TRUE(a->received.empty());
+}
+
+TEST(SwitchTest, ShutdownPropagatesToBranchesAndDefault) {
+  auto a = std::make_shared<Sink>();
+  auto b = std::make_shared<Sink>();
+  auto def = std::make_shared<Sink>();
+  Switch sw(compile(R"({"ref":"value"})"), {a, b}, def);
+
+  EXPECT_EQ(sw.caseCount(), 2u);
+  sw.shutdown();
+  EXPECT_TRUE(a->shutdownCalled.load());
+  EXPECT_TRUE(b->shutdownCalled.load());
+  EXPECT_TRUE(def->shutdownCalled.load());
+
+  sw.onValue(StreamValue{"S", 0.0});  // dropped after shutdown
+  EXPECT_TRUE(a->received.empty());
+}

--- a/tests/treebuilder/TreeBuilderTest.cpp
+++ b/tests/treebuilder/TreeBuilderTest.cpp
@@ -221,6 +221,43 @@ TEST_F(TreeBuilderTestFixture, FilterRejectsMissingWhen) {
     EXPECT_THROW(tree::buildNode(doc, "SYM", deps, terminal), std::runtime_error);
 }
 
+// ----- Switch node (ENC-650) -----
+
+TEST_F(TreeBuilderTestFixture, BuildsSwitchFromJsonAndRoutes) {
+    initDeps();
+    auto terminal = std::make_shared<TerminalStub>();
+    rapidjson::Document doc;
+    // select by value; two Worker(last) cases both forward into the terminal.
+    doc.Parse(R"({
+      "type":"Switch",
+      "select":{"ref":"value"},
+      "cases":[{"type":"Worker","fn":"last"},{"type":"Worker","fn":"last"}]
+    })");
+    auto node = tree::buildNode(doc, "SYM", deps, terminal);
+    ASSERT_TRUE(node);
+
+    node->onValue(StreamValue{"SYM", 1.0});  // routes to case 1 -> terminal
+    node->onValue(StreamValue{"SYM", 9.0});  // out of range, no default -> drop
+    ASSERT_EQ(terminal->received.size(), 1u);
+    EXPECT_DOUBLE_EQ(std::get<double>(terminal->received[0].value), 1.0);
+}
+
+TEST_F(TreeBuilderTestFixture, SwitchRejectsMissingSelect) {
+    initDeps();
+    auto terminal = std::make_shared<TerminalStub>();
+    rapidjson::Document doc;
+    doc.Parse(R"({"type":"Switch","cases":[{"type":"Worker","fn":"last"}]})");
+    EXPECT_THROW(tree::buildNode(doc, "SYM", deps, terminal), std::runtime_error);
+}
+
+TEST_F(TreeBuilderTestFixture, SwitchRejectsEmptyCases) {
+    initDeps();
+    auto terminal = std::make_shared<TerminalStub>();
+    rapidjson::Document doc;
+    doc.Parse(R"({"type":"Switch","select":{"ref":"value"},"cases":[]})");
+    EXPECT_THROW(tree::buildNode(doc, "SYM", deps, terminal), std::runtime_error);
+}
+
 TEST_F(TreeBuilderTestFixture, BuildForRequestBuildsListener) {
     initDeps();
     auto terminal = std::make_shared<TerminalStub>();


### PR DESCRIPTION
Two-pass builder: a Let names producers reused by Ref; each producer built once and fanned (via Tee) to its consumers. Stacked on enc-650. 5 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)