### PR TITLE
ENC-651: capstone composition test + docs

### DIFF
--- a/docs/expression-language.md
+++ b/docs/expression-language.md
@@ -1,0 +1,162 @@
+# Expression Language (request-tree compute model)
+
+GMA_V3 request trees compose a small set of dataflow **nodes** over streaming
+values. This doc covers the *expression-language* layer (project
+`2026-06-17-gma-expression-language`) that turns the fixed reducer menu into a
+composable language: structured values, user-defined formulas, conditionals,
+and reusable bindings.
+
+**Design invariant — bounded cost per tick.** Every node added here is *total*:
+each subscription's per-event cost is statically boundable. There are no loops,
+no recursion, and no data-dependent unbounded work. Expression size is bounded
+by the validator's depth cap (`MAX_TREE_DEPTH = 32`).
+
+---
+
+## Values: scalars and records
+
+A pipeline edge carries an `ArgType` — a scalar (`bool`/`int`/`double`/string),
+a vector, or a **`Record`**: an insertion-ordered set of named fields
+(`include/gma/StreamValue.hpp`). A record lets one pipeline carry e.g. an OHLC
+candle instead of N parallel scalar pipelines. Records serialize to JSON objects
+(`include/gma/util/JsonUtil.hpp`).
+
+### `Pack` — assemble a record (fan-in, combineLatest)
+
+```json
+{"type":"Pack","fields":{
+  "bid":{"type":"Listener","streamKey":"SYM","field":"bid"},
+  "ask":{"type":"Listener","streamKey":"SYM","field":"ask"}
+}}
+```
+
+Each field has its own input subtree. Once **every** field has produced a value
+for a symbol, each subsequent field update emits a `Record` of the latest
+values, in declared order.
+
+### `Field` — extract one field
+
+```json
+{"type":"Field","name":"bid"}
+```
+
+Forwards the named field's value from an incoming record. Non-records and absent
+fields are dropped.
+
+---
+
+## `Expr` — user-defined expressions
+
+Evaluates a compiled expression over each incoming value and forwards the scalar
+result. A **record** input exposes each field as a named ref; a **scalar** input
+is exposed as the ref `"value"`.
+
+```json
+{"type":"Expr","expr":{"op":"div","args":[
+  {"op":"add","args":[{"ref":"bid"},{"ref":"ask"}]}, 2]}}
+```
+
+### Grammar
+
+| Form | Meaning |
+|------|---------|
+| `3.5`, `true` / `{"lit": <num\|bool>}` | literal |
+| `{"ref":"name"}` | named input (0.0 if absent at eval) |
+| `{"op":"<operator>","args":[ … ]}` | operator application |
+| `{"op":"fn","name":"<builtin>","args":[ … ]}` | call a `FunctionMap` builtin |
+
+Operators (numeric; comparisons/logical yield `1.0`/`0.0`, truthy = `> 0.5`):
+
+- **n-ary:** `add` `mul` `min` `max` `and` `or`
+- **binary:** `sub` `div` `mod` `gt` `lt` `gte` `lte` `eq` `neq`
+- **unary:** `neg` `abs` `not`
+
+`div`/`mod` by zero yield `0.0` (finite/total — no NaN/inf). The `fn` bridge
+reaches all ~55 `FunctionMap` builtins (`sum`, `mean`, `sqrt`, …). Malformed
+expressions (unknown op/fn, wrong arity) throw at **build time**, never at eval.
+
+### `select` / `iff` — value-level branch
+
+`select(cond, a, b) → a if cond>0.5 else b` is a `FunctionMap` builtin, most
+useful as a ternary inside an expression:
+
+```json
+{"op":"fn","name":"select","args":[ {"op":"gt","args":[{"ref":"rsi"},70]}, 1, 0 ]}
+```
+
+---
+
+## Control flow
+
+### `Filter` — predicate gate
+
+Forwards each value **unchanged** iff a predicate expression over it is truthy.
+
+```json
+{"type":"Filter","when":{"op":"gt","args":[{"ref":"rsi"},70]}}
+```
+
+### `Switch` — value-conditioned routing
+
+Routes each value (unchanged) to one of N case branches by a selector expression
+(rounded to an index); out-of-range goes to the optional `default`, else drops.
+
+```json
+{"type":"Switch","select":{"ref":"regime"},
+ "cases":[<bear>, <flat>, <bull>], "default":<other>}
+```
+
+---
+
+## Reuse: `Tee`, `Let`, `Ref`
+
+### `Tee` — broadcast fan-out
+
+Forwards each value to **every** output subtree (compute the upstream once, run
+N branches):
+
+```json
+{"type":"Tee","outputs":[<branchA>, <branchB>]}
+```
+
+### `Let` / `Ref` — named bindings (reuse DAG)
+
+A `Let` names producer subtrees that `Ref` taps across its body. Each referenced
+binding's producer is built **once** and fanned (via `Tee`) to all its
+consumers — so an intermediate is computed once, not recomputed per use.
+
+```json
+{"type":"Let",
+ "bindings":{ "mid":{"type":"AtomicAccessor","field":"mid"} },
+ "body":{"type":"Aggregate","arity":2,"inputs":[
+    {"type":"Chain","stages":[{"type":"Ref","name":"mid"}, <exprA>]},
+    {"type":"Chain","stages":[{"type":"Ref","name":"mid"}, <exprB>]}
+ ]}}
+```
+
+Sibling bindings cannot reference each other (no cycles). Bindings are resolved
+at build time, so `Ref` is unsupported inside lazily-built subtrees (e.g.
+`GroupSplit` children).
+
+---
+
+## Worked example — "emit price when RSI > 70"
+
+```
+Pack{rsi, price}  ->  Filter{ when: rsi > 70 }  ->  Field{ price }
+```
+
+```json
+[
+  {"type":"Pack","fields":{
+    "rsi":{"type":"Listener","streamKey":"SYM","field":"rsi"},
+    "price":{"type":"Listener","streamKey":"SYM","field":"price"}
+  }},
+  {"type":"Filter","when":{"op":"gt","args":[{"ref":"rsi"},70]}},
+  {"type":"Field","name":"price"}
+]
+```
+
+The record carries both `rsi` and `price`; the filter gates on `rsi`; the field
+emits `price` only on the ticks that pass. See
+`tests/integration/ExpressionLanguageCapstoneTest.cpp` for the end-to-end test.

--- a/tests/integration/ExpressionLanguageCapstoneTest.cpp
+++ b/tests/integration/ExpressionLanguageCapstoneTest.cpp
@@ -1,0 +1,150 @@
+// Capstone (ENC-651): the expression-language vocabulary composing end-to-end
+// through the real engine — record (Pack/Field), Expr, Filter, and let-bindings
+// together. Proves the pieces interoperate, not just in isolation.
+#include "gma/TreeBuilder.hpp"
+#include "gma/Dispatcher.hpp"
+#include "gma/AtomicStore.hpp"
+#include "gma/rt/ThreadPool.hpp"
+#include "gma/nodes/INode.hpp"
+
+#include <gtest/gtest.h>
+#include <rapidjson/document.h>
+
+#include <algorithm>
+#include <memory>
+#include <mutex>
+#include <vector>
+
+using namespace gma;
+
+namespace {
+
+class Terminal : public INode {
+public:
+  std::mutex mx;
+  std::vector<StreamValue> received;
+  void onValue(const StreamValue& sv) override {
+    std::lock_guard<std::mutex> lk(mx);
+    received.push_back(sv);
+  }
+  void shutdown() noexcept override {}
+  std::size_t size() {
+    std::lock_guard<std::mutex> lk(mx);
+    return received.size();
+  }
+};
+
+struct Rig {
+  rt::ThreadPool pool{1};
+  AtomicStore store;
+  Dispatcher dispatcher{&pool, &store};
+  std::shared_ptr<Terminal> terminal = std::make_shared<Terminal>();
+  tree::Deps deps;
+  Rig() {
+    deps.store = &store;
+    deps.pool = &pool;
+    deps.dispatcher = &dispatcher;
+  }
+  // Build a downstream-first chain of node specs: chain[last] -> terminal, ...,
+  // chain[0] is returned as the head to drive.
+  std::shared_ptr<INode> buildChain(std::initializer_list<const char*> specs) {
+    std::vector<const char*> v(specs);
+    std::shared_ptr<INode> down = terminal;
+    for (auto it = v.rbegin(); it != v.rend(); ++it) {
+      rapidjson::Document d;
+      d.Parse(*it);
+      EXPECT_FALSE(d.HasParseError()) << *it;
+      down = tree::buildNode(d, "SYM", deps, down);
+    }
+    return down;
+  }
+  double at(std::size_t i) { return std::get<double>(terminal->received[i].value); }
+};
+
+} // namespace
+
+// "Emit the price whenever RSI > 70" — Pack(rsi,price) -> Filter(rsi>70) ->
+// Field(price). Record + Filter + Field composed end-to-end.
+TEST(ExpressionLanguageCapstoneTest, EmitPriceWhenRsiAboveThreshold) {
+  Rig rig;
+  auto head = rig.buildChain({
+    R"({"type":"Pack","fields":{
+        "rsi":{"type":"Listener","streamKey":"SYM","field":"rsi"},
+        "price":{"type":"Listener","streamKey":"SYM","field":"price"}
+    }})",
+    R"({"type":"Filter","when":{"op":"gt","args":[{"ref":"rsi"},70]}})",
+    R"({"type":"Field","name":"price"})"
+  });
+  ASSERT_TRUE(head);
+
+  rig.dispatcher.notifyListeners("SYM", "price", 100.0);  // price latest = 100
+  rig.dispatcher.notifyListeners("SYM", "rsi", 80.0);     // complete, 80>70  -> emit 100
+  rig.dispatcher.notifyListeners("SYM", "rsi", 50.0);     // 50>70 false      -> drop
+  rig.dispatcher.notifyListeners("SYM", "rsi", 90.0);     // 90>70            -> emit 100
+  rig.pool.shutdown();
+
+  ASSERT_EQ(rig.terminal->size(), 2u);
+  EXPECT_DOUBLE_EQ(rig.at(0), 100.0);
+  EXPECT_DOUBLE_EQ(rig.at(1), 100.0);
+}
+
+// Derived signal: Pack(bid,ask) -> Expr((bid+ask)/2) — record + expression.
+TEST(ExpressionLanguageCapstoneTest, ExprComputesMidFromRecord) {
+  Rig rig;
+  auto head = rig.buildChain({
+    R"({"type":"Pack","fields":{
+        "bid":{"type":"Listener","streamKey":"SYM","field":"bid"},
+        "ask":{"type":"Listener","streamKey":"SYM","field":"ask"}
+    }})",
+    R"({"type":"Expr","expr":{"op":"div","args":[
+        {"op":"add","args":[{"ref":"bid"},{"ref":"ask"}]}, 2]}})"
+  });
+  ASSERT_TRUE(head);
+
+  rig.dispatcher.notifyListeners("SYM", "bid", 10.0);
+  rig.dispatcher.notifyListeners("SYM", "ask", 12.0);   // complete -> (10+12)/2 = 11
+  rig.pool.shutdown();
+
+  ASSERT_EQ(rig.terminal->size(), 1u);
+  EXPECT_DOUBLE_EQ(rig.at(0), 11.0);
+}
+
+// Reuse: a let-binding feeds two derived expressions; the source is produced
+// once and fanned to both. Each Aggregate input is Chain[Ref(p) -> Expr], so
+// the single price event drives two distinct expressions over the shared value.
+TEST(ExpressionLanguageCapstoneTest, LetBindingReusedByTwoExpressions) {
+  Rig rig;
+  rapidjson::Document doc;
+  doc.Parse(R"({
+    "type":"Let",
+    "bindings":{ "p":{"type":"Listener","streamKey":"SYM","field":"price"} },
+    "body":{
+      "type":"Aggregate","arity":2,
+      "inputs":[
+        {"type":"Chain","stages":[
+          {"type":"Ref","name":"p"},
+          {"type":"Expr","expr":{"op":"mul","args":[{"ref":"value"},10]}}
+        ]},
+        {"type":"Chain","stages":[
+          {"type":"Ref","name":"p"},
+          {"type":"Expr","expr":{"op":"add","args":[{"ref":"value"},1]}}
+        ]}
+      ]
+    }
+  })");
+  ASSERT_FALSE(doc.HasParseError());
+
+  auto root = tree::buildNode(doc, "SYM", rig.deps, rig.terminal);
+  ASSERT_TRUE(root);
+
+  rig.dispatcher.notifyListeners("SYM", "price", 4.0);  // 4*10=40 and 4+1=5
+  rig.pool.shutdown();
+
+  // Aggregate(2) collects both derived values from the single source event.
+  ASSERT_EQ(rig.terminal->size(), 2u);
+  std::vector<double> got{rig.at(0), rig.at(1)};
+  std::sort(got.begin(), got.end());
+  EXPECT_DOUBLE_EQ(got[0], 5.0);    // value + 1
+  EXPECT_DOUBLE_EQ(got[1], 40.0);   // value * 10
+  root->shutdown();
+}


### PR DESCRIPTION
Lands the ENC-651 capstone (end-to-end composition test + docs/expression-language.md) on master. The original stacked PR #37 was auto-closed during the stacked merge; this is a clean re-land off master.

Closes ENC-651.

🤖 Generated with [Claude Code](https://claude.com/claude-code)